### PR TITLE
fix(frontend): invalidate cached translation JSON after deploy

### DIFF
--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -11,13 +11,12 @@ import { APP_INITIALIZER, importProvidersFrom } from '@angular/core';
 
 import { appRoutes } from './app.routes';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
-import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { appInitializer } from './app.init';
 import { errorInterceptor } from '../services/error-interceptor.service';
+import { VersionedTranslateHttpLoader } from './versioned-translate-http-loader';
 
-// Factory function for TranslateHttpLoader
-export function HttpLoaderFactory(http: HttpClient) {
-  return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+export function translateLoaderFactory(http: HttpClient) {
+  return new VersionedTranslateHttpLoader(http);
 }
 
 export const appConfig: ApplicationConfig = {
@@ -30,7 +29,7 @@ export const appConfig: ApplicationConfig = {
       TranslateModule.forRoot({
         loader: {
           provide: TranslateLoader,
-          useFactory: HttpLoaderFactory,
+          useFactory: translateLoaderFactory,
           deps: [HttpClient],
         },
         defaultLanguage: 'he',

--- a/apps/frontend/src/app/versioned-translate-http-loader.ts
+++ b/apps/frontend/src/app/versioned-translate-http-loader.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { TranslateLoader, TranslationObject } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
+
+/**
+ * Loads i18n JSON with a version query so browsers/CDNs fetch fresh files after each deploy.
+ * Keep {@link environment.version} in sync with releases (or inject at build time).
+ */
+@Injectable()
+export class VersionedTranslateHttpLoader implements TranslateLoader {
+  constructor(private readonly http: HttpClient) {}
+
+  getTranslation(lang: string): Observable<TranslationObject> {
+    const v = encodeURIComponent(environment.version);
+    return this.http.get<TranslationObject>(
+      `./assets/i18n/${lang}.json?v=${v}`,
+    );
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
`TranslateHttpLoader` requested static files like `./assets/i18n/en.json` with no cache-busting. After a deploy with updated translation keys or values, browsers and CDNs could keep serving the old JSON.

## Approach
Introduce `VersionedTranslateHttpLoader`, which appends `?v=<environment.version>` to each translation request. That makes the URL change whenever the app version changes (same `version` field already used in the UI, e.g. top bar).

## Deploy note
Ensure `environment.version` (and prod file replacement) is bumped for each release that changes translations, or inject the version in CI so it always matches the build artifact.

## Verification
- `nx run frontend:build:development` succeeds after merging latest `develop`.
- Repo `frontend:lint` / `frontend:test` still report existing failures in other files (unchanged by this PR).

---

*Branch updated: merged `develop` into this PR (resolved `app.config.ts` conflict by keeping both `RuntimeConfigService` from develop and `VersionedTranslateHttpLoader`).*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee9ddb65-5cb3-44e3-829c-e14f402c975c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee9ddb65-5cb3-44e3-829c-e14f402c975c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

