### PR TITLE
Serialize fullstack deploy workflow to avoid parallel AWS conflicts

### DIFF
--- a/.github/workflows/deploy-fullstack.yml
+++ b/.github/workflows/deploy-fullstack.yml
@@ -7,6 +7,12 @@ on:
     tags:
       - 'v*'
 
+# Serialize deployments per environment so parallel merges to develop (or concurrent
+# tag pushes) do not run two full-stack deploys at once and race on AWS resources.
+concurrency:
+  group: deploy-fullstack-${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'development' }}
+  cancel-in-progress: false
+
 env:
   # Use the correct lowercase AWS region identifier.
   AWS_REGION: il-central-1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a workflow-level **concurrency** group to `.github/workflows/deploy-fullstack.yml` so multiple pushes that trigger this workflow do not run two full-stack deployments at the same time.

## Behavior

- **`cancel-in-progress: false`** — newer runs **wait** for the in-progress run to finish (no cancellation).
- **Group key** matches deployment intent:
  - `deploy-fullstack-development` for pushes to `develop`
  - `deploy-fullstack-production` for version tags (`v*`)

This prevents races when two PRs merge to `develop` in quick succession (or concurrent production tag pushes).

## References

- [GitHub Actions: concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6edd7e0-fc07-4ebf-a063-018d01873be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6edd7e0-fc07-4ebf-a063-018d01873be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

