### PR TITLE
docs(e2E): complete E2E runbook (issue closure notes in PR body)

### DIFF
--- a/docs/local-e2e.md
+++ b/docs/local-e2e.md
@@ -97,3 +97,32 @@ This uses `apps/frontend-e2e/playwright.deployed.config.ts` (no local web server
 Organization:
 
 - `org-e2e-main`
+
+## Environment variables (local)
+
+| Variable | Typical value | Purpose |
+|----------|---------------|---------|
+| `E2E_AUTH_SECRET` | `e2e-local-secret` (local default) | Shared secret for `/api/auth/e2e-login` |
+| `E2E_AUTH_ENABLED` | `true` | Enables the test-only login path on the backend |
+| `BACKEND_BASE_URL` | `http://localhost:3000` | API base for Playwright / API tests |
+| `BASE_URL` | `http://localhost:4200` | Frontend base for Playwright |
+| `E2E_SKIP_LOCAL_E2E_ENSURE` | `true` | Skip ensure script when infra was prepared already (e.g. CI after `e2e:local:prepare`) |
+| `E2E_SKIP_LOCALSTACK_AUTO_UP` | `true` | Do not start Docker from the ensure script; expect LocalStack already running |
+| `STAGE` | `local` | Backend stage for table/bucket naming |
+| `AWS_ENDPOINT_URL*` | `http://localhost:4566` | LocalStack endpoints for AWS SDK (see `backend:serve:e2e-local` in `package.json`) |
+
+Deployed runs additionally use the GitHub Environment secret `E2E_AUTH_SECRET` and manual `base_url` / `backend_base_url` inputs; see [github-environments-setup.md](./github-environments-setup.md#-e2e-workflow-environment-secrets).
+
+## CI behavior
+
+- **LocalStack core regression**: `.github/workflows/e2e-localstack-core-regression.yml` runs on pull requests targeting `main` / `develop` and on pushes to `develop`. It runs lint + unit tests, then `e2e:local:prepare` and `nx run frontend-e2e:e2e-local-core` (Chromium, `workers=1`). Artifacts: Playwright HTML report and `test-results`, plus a summarized failure context log.
+- **Deployed core regression**: `.github/workflows/e2e-deployed-core-regression.yml` is **manual** (`workflow_dispatch`): pick environment, frontend URL, and API URL. It does not start local Docker.
+
+## Troubleshooting
+
+- **LocalStack not healthy**: Run `npm run e2e:local:stack:down` then `npm run e2e:local:prepare`, or `npm run e2e:local:stack:reset` for a clean volume.
+- **Port 4566 / 3000 / 4200 in use**: Stop conflicting processes or adjust compose ports / `BACKEND_BASE_URL` / `BASE_URL` consistently in Playwright env.
+- **Playwright “browser not installed”**: Run `npm run e2e:local:install-browsers` or `npx playwright install chromium`.
+- **Auth failures in tests**: Ensure backend was started with `E2E_AUTH_ENABLED=true` and the same `E2E_AUTH_SECRET` the tests use (`e2e-local-secret` for local scripts).
+- **Flaky Nx cache on E2E**: `frontend-e2e` e2e targets set `cache: false`; if you run Playwright outside Nx, do not rely on cached failures as green.
+- **CI failures**: Download the workflow artifacts (report + test-results) and check the “Summarize Playwright failure contexts” step output.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

E2E epic (#40–#53) is already implemented on `develop` (see #54 and related commits). This PR only expands `docs/local-e2e.md` with environment variables, CI behavior, and troubleshooting so **E2E-0701** is fully satisfied.

The automation user (`gh`) cannot close GitHub issues (token: “Resource not accessible by integration”). **Please close #40–#53 manually** using the comments below (reason: **Completed**).

### Suggested closing comments (copy per issue)

- **#40** — Done on `develop`: inventory transfer source/destination lookup fixed; coverage in `apps/backend/src/services/inventory-transfer.service.spec.ts` (see also #54).

- **#41** — Done: stable `data-testid` across login, shell nav, forms, create-form, inventory, signature pad, etc.; consumed by Playwright under `apps/frontend-e2e/`.

- **#42** — Done: `docker-compose.e2e.yml` runs LocalStack; frontend + backend are started by Playwright `webServer` (`playwright.config.ts`) via `npm run backend:serve:e2e-local` / `frontend:serve:e2e-local`.

- **#43** — Done: `scripts/setup-local-e2e.js` provisions DynamoDB tables, S3 bucket, and Secrets Manager entries against LocalStack.

- **#44** — Done: deterministic seed via `scripts/seed-e2e-data.js`; orchestrated by `scripts/setup-local-e2e.js` and `scripts/ensure-local-e2e-before-playwright.js`.

- **#45** — Done: `apps/backend/src/local-http-server.ts` exposes Lambda-style handlers over HTTP for local E2E.

- **#46** — Done: guarded `/api/auth/e2e-login` in `apps/backend/src/api/auth/e2e-login.ts` (`E2E_AUTH_ENABLED`, `E2E_AUTH_SECRET`).

- **#47** — Done: `apps/backend/src/services/aws-client-config.service.ts` centralizes endpoint overrides for LocalStack.

- **#48** — Done: runtime API URL via `RuntimeConfigService`, `scripts/write-runtime-config.js`, and `assets/runtime-config.json`.

- **#49** — Done: `apps/frontend-e2e/src/helpers/`, `playwright.config.ts` / `playwright.deployed.config.ts`, traces on first retry.

- **#50** — Done: `core-regression.spec.ts` (API) and `core-regression-ui.spec.ts` (UI) for forms, approval, inventory validation.

- **#51** — Done: `.github/workflows/e2e-localstack-core-regression.yml` on PRs to `main`/`develop` and pushes to `develop`.

- **#52** — Done: `.github/workflows/e2e-deployed-core-regression.yml` as manual `workflow_dispatch` with environment `E2E_AUTH_SECRET`; optional follow-up: auto-trigger after deploy if stable URLs are available as secrets/vars.

- **#53** — Done: `docs/local-e2e.md` + E2E sections in `docs/github-environments-setup.md`; this PR extends the runbook further.

## Files

- `docs/local-e2e.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee983df1-aecf-426f-a1b3-25dd55e987a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee983df1-aecf-426f-a1b3-25dd55e987a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

