### PR TITLE
ci(e2e): auto-run deployed Playwright after develop full-stack deploy

### DIFF
--- a/.github/workflows/e2e-deployed-after-develop-deploy.yml
+++ b/.github/workflows/e2e-deployed-after-develop-deploy.yml
@@ -1,0 +1,31 @@
+name: E2E Deployed Core After Develop Deploy
+
+# Runs the same Playwright suite as the manual deployed workflow after a successful
+# "Deploy Full Stack to AWS" run on `develop`. Requires repository variables
+# `E2E_DEV_FRONTEND_URL` and `E2E_DEV_BACKEND_URL` (see docs/local-e2e.md).
+
+on:
+  workflow_run:
+    workflows:
+      - Deploy Full Stack to AWS
+    types:
+      - completed
+    branches:
+      - develop
+
+jobs:
+  deployed-core-regression:
+    uses: ./.github/workflows/e2e-deployed-core-reusable.yml
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'develop' &&
+      vars.E2E_DEV_FRONTEND_URL != '' &&
+      vars.E2E_DEV_BACKEND_URL != ''
+    with:
+      base_url: ${{ vars.E2E_DEV_FRONTEND_URL }}
+      backend_base_url: ${{ vars.E2E_DEV_BACKEND_URL }}
+      target_environment: development
+      checkout_ref: ${{ github.event.workflow_run.head_sha }}
+      artifact_suffix: deployed-core-after-develop
+      summarize_label: deployed-after-develop
+    secrets: inherit

--- a/.github/workflows/e2e-deployed-core-regression.yml
+++ b/.github/workflows/e2e-deployed-core-regression.yml
@@ -22,51 +22,12 @@ on:
 
 jobs:
   deployed-core-regression:
-    name: Core regression (deployed)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment: ${{ github.event.inputs.target_environment }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browser dependencies
-        run: npx playwright install --with-deps chromium
-
-      - name: Run deployed core regression
-        env:
-          BASE_URL: ${{ github.event.inputs.base_url }}
-          BACKEND_BASE_URL: ${{ github.event.inputs.backend_base_url }}
-          E2E_AUTH_SECRET: ${{ secrets.E2E_AUTH_SECRET }}
-          PLAYWRIGHT_HTML_OPEN: never
-        run: npx nx run frontend-e2e:e2e-deployed-core
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report-deployed-core
-          path: playwright-report
-          if-no-files-found: ignore
-
-      - name: Upload Playwright test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-test-results-deployed-core
-          path: test-results
-          if-no-files-found: ignore
-
-      - name: Summarize Playwright failure contexts
-        if: always()
-        run: python3 scripts/summarize-playwright-error-contexts.py --label deployed
+    uses: ./.github/workflows/e2e-deployed-core-reusable.yml
+    with:
+      base_url: ${{ github.event.inputs.base_url }}
+      backend_base_url: ${{ github.event.inputs.backend_base_url }}
+      target_environment: ${{ github.event.inputs.target_environment }}
+      checkout_ref: ${{ github.sha }}
+      artifact_suffix: deployed-core-manual
+      summarize_label: deployed
+    secrets: inherit

--- a/.github/workflows/e2e-deployed-core-reusable.yml
+++ b/.github/workflows/e2e-deployed-core-reusable.yml
@@ -1,0 +1,84 @@
+name: E2E Deployed Core (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      base_url:
+        description: Frontend base URL
+        required: true
+        type: string
+      backend_base_url:
+        description: Backend API base URL
+        required: true
+        type: string
+      target_environment:
+        description: GitHub Environment (for E2E_AUTH_SECRET)
+        required: true
+        type: string
+      checkout_ref:
+        description: Git commit SHA to checkout (tests run against this revision)
+        required: true
+        type: string
+      artifact_suffix:
+        description: Suffix for Playwright artifact names
+        required: false
+        type: string
+        default: deployed-core
+      summarize_label:
+        description: Label passed to summarize-playwright-error-contexts.py
+        required: false
+        type: string
+        default: deployed
+
+jobs:
+  deployed-core-regression:
+    name: Core regression (deployed)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: ${{ inputs.target_environment }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: Run deployed core regression
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+          BACKEND_BASE_URL: ${{ inputs.backend_base_url }}
+          E2E_AUTH_SECRET: ${{ secrets.E2E_AUTH_SECRET }}
+          PLAYWRIGHT_HTML_OPEN: never
+        run: npx nx run frontend-e2e:e2e-deployed-core
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ inputs.artifact_suffix }}
+          path: playwright-report
+          if-no-files-found: ignore
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-${{ inputs.artifact_suffix }}
+          path: test-results
+          if-no-files-found: ignore
+
+      - name: Summarize Playwright failure contexts
+        if: always()
+        run: python3 scripts/summarize-playwright-error-contexts.py --label ${{ inputs.summarize_label }}

--- a/docs/github-environments-setup.md
+++ b/docs/github-environments-setup.md
@@ -123,7 +123,7 @@ For enhanced security, migrate from access keys to OIDC:
 
 ## 🧪 E2E Workflow Environment Secrets
 
-The deployed regression workflow (`.github/workflows/e2e-deployed-core-regression.yml`) reads:
+Deployed Playwright regression (manual and automatic) uses the reusable workflow `.github/workflows/e2e-deployed-core-reusable.yml` and reads:
 
 - `E2E_AUTH_SECRET` (from the selected GitHub Environment)
 
@@ -132,7 +132,18 @@ Add this secret to each environment:
 - **development** → `E2E_AUTH_SECRET` for your dev API
 - **production** → `E2E_AUTH_SECRET` for your production API
 
-When manually running the workflow:
+### Repository variables (optional — auto E2E after develop deploy)
+
+Workflow **E2E Deployed Core After Develop Deploy** (`.github/workflows/e2e-deployed-after-develop-deploy.yml`) runs after a successful **Deploy Full Stack to AWS** on `develop`. It only runs when **both** of these **Actions variables** are non-empty (repository **Settings → Secrets and variables → Actions → Variables**):
+
+| Variable | Example | Purpose |
+|----------|---------|---------|
+| `E2E_DEV_FRONTEND_URL` | `https://app.dev.equip-track.com` | Deployed frontend base URL |
+| `E2E_DEV_BACKEND_URL` | `https://api.dev.equip-track.com` | Deployed API base URL |
+
+If either is unset, the workflow is skipped (no failure). The job uses the **development** environment for `E2E_AUTH_SECRET`.
+
+### Manual deployed E2E
 
 1. Open **Actions** → **E2E Deployed Core Regression**
 2. Click **Run workflow**

--- a/docs/local-e2e.md
+++ b/docs/local-e2e.md
@@ -97,3 +97,32 @@ This uses `apps/frontend-e2e/playwright.deployed.config.ts` (no local web server
 Organization:
 
 - `org-e2e-main`
+
+## Environment variables (local)
+
+| Variable | Typical value | Purpose |
+|----------|---------------|---------|
+| `E2E_AUTH_SECRET` | `e2e-local-secret` (local default) | Shared secret for `/api/auth/e2e-login` |
+| `E2E_AUTH_ENABLED` | `true` | Enables the test-only login path on the backend |
+| `BACKEND_BASE_URL` | `http://localhost:3000` | API base for Playwright / API tests |
+| `BASE_URL` | `http://localhost:4200` | Frontend base for Playwright |
+| `E2E_SKIP_LOCAL_E2E_ENSURE` | `true` | Skip ensure script when infra was prepared already (e.g. CI after `e2e:local:prepare`) |
+| `E2E_SKIP_LOCALSTACK_AUTO_UP` | `true` | Do not start Docker from the ensure script; expect LocalStack already running |
+| `STAGE` | `local` | Backend stage for table/bucket naming |
+| `AWS_ENDPOINT_URL*` | `http://localhost:4566` | LocalStack endpoints for AWS SDK (see `backend:serve:e2e-local` in `package.json`) |
+
+Deployed runs additionally use the GitHub Environment secret `E2E_AUTH_SECRET` and manual `base_url` / `backend_base_url` inputs; see [github-environments-setup.md](./github-environments-setup.md#-e2e-workflow-environment-secrets).
+
+## CI behavior
+
+- **LocalStack core regression**: `.github/workflows/e2e-localstack-core-regression.yml` runs on pull requests targeting `main` / `develop` and on pushes to `develop`. It runs lint + unit tests, then `e2e:local:prepare` and `nx run frontend-e2e:e2e-local-core` (Chromium, `workers=1`). Artifacts: Playwright HTML report and `test-results`, plus a summarized failure context log.
+- **Deployed core regression**: `.github/workflows/e2e-deployed-core-regression.yml` is **manual** (`workflow_dispatch`): pick environment, frontend URL, and API URL. It does not start local Docker.
+
+## Troubleshooting
+
+- **LocalStack not healthy**: Run `npm run e2e:local:stack:down` then `npm run e2e:local:prepare`, or `npm run e2e:local:stack:reset` for a clean volume.
+- **Port 4566 / 3000 / 4200 in use**: Stop conflicting processes or adjust compose ports / `BACKEND_BASE_URL` / `BASE_URL` consistently in Playwright env.
+- **Playwright “browser not installed”**: Run `npm run e2e:local:install-browsers` or `npx playwright install chromium`.
+- **Auth failures in tests**: Ensure backend was started with `E2E_AUTH_ENABLED=true` and the same `E2E_AUTH_SECRET` the tests use (`e2e-local-secret` for local scripts).
+- **Flaky Nx cache on E2E**: `frontend-e2e` e2e targets set `cache: false`; if you run Playwright outside Nx, do not rely on cached failures as green.
+- **CI failures**: Download the workflow artifacts (report + test-results) and check the “Summarize Playwright failure contexts” step output.

--- a/docs/local-e2e.md
+++ b/docs/local-e2e.md
@@ -116,7 +116,8 @@ Deployed runs additionally use the GitHub Environment secret `E2E_AUTH_SECRET` a
 ## CI behavior
 
 - **LocalStack core regression**: `.github/workflows/e2e-localstack-core-regression.yml` runs on pull requests targeting `main` / `develop` and on pushes to `develop`. It runs lint + unit tests, then `e2e:local:prepare` and `nx run frontend-e2e:e2e-local-core` (Chromium, `workers=1`). Artifacts: Playwright HTML report and `test-results`, plus a summarized failure context log.
-- **Deployed core regression**: `.github/workflows/e2e-deployed-core-regression.yml` is **manual** (`workflow_dispatch`): pick environment, frontend URL, and API URL. It does not start local Docker.
+- **Deployed core regression (manual)**: `.github/workflows/e2e-deployed-core-regression.yml` is **`workflow_dispatch`**: pick environment, frontend URL, and API URL. It does not start local Docker.
+- **Deployed core regression (after develop deploy)**: `.github/workflows/e2e-deployed-after-develop-deploy.yml` runs when [Deploy Full Stack to AWS](.github/workflows/deploy-fullstack.yml) completes successfully on `develop`. It is **skipped** unless repository variables `E2E_DEV_FRONTEND_URL` and `E2E_DEV_BACKEND_URL` are set (Settings → Secrets and variables → Actions → Variables). It checks out the same commit as the deploy (`workflow_run.head_sha`) and uses the **development** GitHub Environment for `E2E_AUTH_SECRET`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- **Reusable workflow** `.github/workflows/e2e-deployed-core-reusable.yml` — shared steps for installed Playwright + `nx run frontend-e2e:e2e-deployed-core`, artifacts, and failure summary.
- **Manual workflow** `.github/workflows/e2e-deployed-core-regression.yml` — now calls the reusable workflow with `checkout_ref: ${{ github.sha }}` and suffix `deployed-core-manual`.
- **New** `.github/workflows/e2e-deployed-after-develop-deploy.yml` — triggers on successful **Deploy Full Stack to AWS** for `develop`, checks out `workflow_run.head_sha`, runs the same suite against URLs from repository variables. **Skipped** (no failure) if either variable is unset.

## Repository setup (required for auto E2E)

Under **Settings → Secrets and variables → Actions → Variables**, set:

| Variable | Purpose |
|----------|---------|
| `E2E_DEV_FRONTEND_URL` | Deployed dev frontend base URL |
| `E2E_DEV_BACKEND_URL` | Deployed dev API base URL |

The **development** environment must still define `E2E_AUTH_SECRET` (unchanged).

## Docs

- `docs/local-e2e.md` — CI behavior for the new workflow; deduplicated the short CI section.
- `docs/github-environments-setup.md` — variables table and pointer to the new workflow.

## Note

Merged the prior remote state of `cursor/e2e-testing-project-plan-8b79` (PR #70 history) into this branch to allow a fast-forwardable push.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee983df1-aecf-426f-a1b3-25dd55e987a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee983df1-aecf-426f-a1b3-25dd55e987a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

