### PR TITLE
docs(e2e): close E2E epic issues #41–#53; map tickets in runbook

### DIFF
--- a/docs/local-e2e.md
+++ b/docs/local-e2e.md
@@ -121,3 +121,7 @@ Deployed runs use the GitHub Environment secret `E2E_AUTH_SECRET` plus URLs from
 - **Auth failures in tests**: Ensure backend was started with `E2E_AUTH_ENABLED=true` and the same `E2E_AUTH_SECRET` the tests use (`e2e-local-secret` for local scripts).
 - **Flaky Nx cache on E2E**: `frontend-e2e` e2e targets set `cache: false`; if you run Playwright outside Nx, do not rely on cached failures as green.
 - **CI failures**: Download the workflow artifacts (report + test-results) and check the “Summarize Playwright failure contexts” step output.
+
+## GitHub epic (issue mapping)
+
+The end-to-end testing initiative was tracked as **E2E-0002** through **E2E-0701** on GitHub. Implementation is on `develop`; prerequisite **E2E-0001** is [#40](https://github.com/NetanelAlbert/EquipTrack/issues/40) (closed). Remaining epic tickets [#41](https://github.com/NetanelAlbert/EquipTrack/issues/41)–[#53](https://github.com/NetanelAlbert/EquipTrack/issues/53) map to: stable `data-testid` selectors; LocalStack compose + bootstrap + seed scripts; local HTTP adapter; guarded `e2e-login`; AWS endpoint overrides; frontend runtime API URL; Playwright helpers and core regression specs; blocking LocalStack CI; manual and post-`develop`-deploy deployed workflows; and this runbook (plus [github-environments-setup.md](./github-environments-setup.md)). Notable merges: [#54](https://github.com/NetanelAlbert/EquipTrack/pull/54), [#70](https://github.com/NetanelAlbert/EquipTrack/pull/70), [#71](https://github.com/NetanelAlbert/EquipTrack/pull/71).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The work for **E2E-0002** through **E2E-0701** is already on `develop` (see [#54](https://github.com/NetanelAlbert/EquipTrack/pull/54), [#70](https://github.com/NetanelAlbert/EquipTrack/pull/70), [#71](https://github.com/NetanelAlbert/EquipTrack/pull/71)). This PR only adds a **GitHub epic (issue mapping)** section to [`docs/local-e2e.md`](docs/local-e2e.md) so the issue list and main integration PRs are discoverable from the runbook.

Prerequisite **E2E-0001** ([#40](https://github.com/NetanelAlbert/EquipTrack/issues/40)) is already closed.

## Issues closed when this PR merges

Closes #41
Closes #42
Closes #43
Closes #44
Closes #45
Closes #46
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
Closes #52
Closes #53

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee983df1-aecf-426f-a1b3-25dd55e987a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee983df1-aecf-426f-a1b3-25dd55e987a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

