### PR TITLE
fix(deploy): enable E2E login env on dev Lambdas for deployed core regression

### DIFF
--- a/.github/workflows/deploy-fullstack.yml
+++ b/.github/workflows/deploy-fullstack.yml
@@ -218,6 +218,11 @@ jobs:
       - name: Deploy Lambda functions
         id: deploy-lambdas
         if: steps.scope.outputs.deploy_backend == 'true'
+        env:
+          # Non-tag pushes (develop): enable e2e-login for deployed Playwright regression.
+          # Version tags (production): omit E2E env on Lambdas (see scripts/deploy-lambdas.js).
+          E2E_AUTH_ENABLED: ${{ !startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
+          E2E_AUTH_SECRET: ${{ secrets.E2E_AUTH_SECRET }}
         run: |
           node scripts/deployment-status-tracker.js track lambda-deploy started
           node scripts/deploy-lambdas.js --parallel

--- a/.github/workflows/deploy-fullstack.yml
+++ b/.github/workflows/deploy-fullstack.yml
@@ -217,9 +217,8 @@ jobs:
         id: deploy-lambdas
         if: steps.scope.outputs.deploy_backend == 'true'
         env:
-          # Non-tag pushes (develop): enable e2e-login for deployed Playwright regression.
-          # Version tags (production): omit E2E env on Lambdas (see scripts/deploy-lambdas.js).
-          E2E_AUTH_ENABLED: ${{ !startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
+          # Align with workflow STAGE: dev (prerelease tags, hyphen in ref) enables e2e-login for deployed Playwright; production tags do not.
+          E2E_AUTH_ENABLED: ${{ env.STAGE == 'dev' && 'true' || 'false' }}
           E2E_AUTH_SECRET: ${{ secrets.E2E_AUTH_SECRET }}
         run: |
           node scripts/deployment-status-tracker.js track lambda-deploy started

--- a/.github/workflows/e2e-deployed-after-develop-deploy.yml
+++ b/.github/workflows/e2e-deployed-after-develop-deploy.yml
@@ -1,8 +1,9 @@
 name: E2E Deployed Core After Develop Deploy
 
 # Runs the same Playwright suite as the manual deployed workflow after a successful
-# "Deploy Full Stack to AWS" run on `develop`. Requires repository variables
-# `E2E_DEV_FRONTEND_URL` and `E2E_DEV_BACKEND_URL` (see docs/local-e2e.md).
+# dev-stage "Deploy Full Stack to AWS" run. Deploy is triggered by version tags;
+# prerelease tags use a hyphen (e.g. v0.0.12-beta.0), matching deploy-fullstack STAGE=dev.
+# Requires repository variables `E2E_DEV_FRONTEND_URL` and `E2E_DEV_BACKEND_URL` (see docs/local-e2e.md).
 
 on:
   workflow_run:
@@ -10,15 +11,14 @@ on:
       - Deploy Full Stack to AWS
     types:
       - completed
-    branches:
-      - develop
 
 jobs:
   deployed-core-regression:
     uses: ./.github/workflows/e2e-deployed-core-reusable.yml
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'develop' &&
+      (github.event.workflow_run.head_branch == 'develop' ||
+        contains(github.event.workflow_run.head_branch, '-')) &&
       vars.E2E_DEV_FRONTEND_URL != '' &&
       vars.E2E_DEV_BACKEND_URL != ''
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 
 # Deployment artifacts
 lambda-packages/
+lambda-deploy-environment-*.json
 deployment-info.json
 endpoints-config.json
 website-config.json

--- a/scripts/deploy-lambdas.js
+++ b/scripts/deploy-lambdas.js
@@ -2,6 +2,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('node:url');
 const { getHandlerNames } = require('./create-lambda-packages');
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
@@ -16,6 +17,44 @@ const LAMBDA_CONFIG = {
   timeout: 30,
   memorySize: 256,
 };
+
+function lambdaEnvFilePath(handlerName) {
+  return path.join(process.cwd(), `lambda-deploy-environment-${handlerName}.json`);
+}
+
+/**
+ * Writes Lambda environment JSON for AWS CLI (--environment file://...).
+ * When E2E_AUTH_ENABLED=true and E2E_AUTH_SECRET is set, configures deployed
+ * `/api/auth/e2e-login` (dev/stage); otherwise only STAGE (matches prior behavior).
+ * One file per handler so parallel deploys do not clobber each other.
+ */
+function writeLambdaEnvironmentFile(handlerName) {
+  const variables = { STAGE };
+  if (process.env.E2E_AUTH_ENABLED === 'true' && process.env.E2E_AUTH_SECRET) {
+    variables.E2E_AUTH_ENABLED = 'true';
+    variables.E2E_AUTH_SECRET = process.env.E2E_AUTH_SECRET;
+  } else if (process.env.E2E_AUTH_ENABLED === 'true') {
+    console.warn(
+      '⚠️ E2E_AUTH_ENABLED is true but E2E_AUTH_SECRET is empty — Lambdas will not get E2E auth env'
+    );
+  }
+  fs.writeFileSync(lambdaEnvFilePath(handlerName), JSON.stringify({ Variables: variables }));
+}
+
+function removeLambdaEnvironmentFile(handlerName) {
+  try {
+    const filePath = lambdaEnvFilePath(handlerName);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function lambdaEnvironmentCliArg(handlerName) {
+  return pathToFileURL(lambdaEnvFilePath(handlerName)).href;
+}
 
 function getLambdaPolicyDocument() {
   return {
@@ -255,72 +294,77 @@ async function waitForLambdaUpdate(functionName, maxAttempts = 12) {
 async function deployLambdaFunction(handlerName, roleArn) {
   const functionName = `equip-track-${handlerName}-${STAGE}`;
   const zipPath = path.join(PACKAGES_DIR, `${handlerName}.zip`);
-  
+
   if (!fs.existsSync(zipPath)) {
     throw new Error(`Package not found: ${zipPath}`);
   }
-  
-  let functionExists = false;
-  
-  // Check if function exists
+
+  writeLambdaEnvironmentFile(handlerName);
+  const envFileArg = lambdaEnvironmentCliArg(handlerName);
+
   try {
-    execSync(`aws lambda get-function --function-name ${functionName}`, { stdio: 'pipe' });
-    functionExists = true;
-  } catch (error) {
-    functionExists = false;
-  }
-  
-  if (functionExists) {
-    // Update existing function
-    console.log(`Updating Lambda function: ${functionName}`);
+    let functionExists = false;
+
     try {
-      execSync(
-        `aws lambda update-function-code --function-name ${functionName} --zip-file fileb://${zipPath}`,
-        { stdio: 'inherit' }
-      );
-      
-      // Wait for code update to complete before updating configuration
-      if (await waitForLambdaUpdate(functionName)) {
-        try {
-          execSync(
-            `aws lambda update-function-configuration --function-name ${functionName} ` +
-            `--timeout ${LAMBDA_CONFIG.timeout} --memory-size ${LAMBDA_CONFIG.memorySize} ` +
-            `--environment "Variables={STAGE=${STAGE}}"`,
-            { stdio: 'inherit' }
-          );
-        } catch (configError) {
-          if (configError.message.includes('ResourceConflictException')) {
-            console.log(`⚠️ Configuration update skipped for ${functionName} - update still in progress`);
-          } else {
-            throw configError;
+      execSync(`aws lambda get-function --function-name ${functionName}`, { stdio: 'pipe' });
+      functionExists = true;
+    } catch (error) {
+      functionExists = false;
+    }
+
+    if (functionExists) {
+      console.log(`Updating Lambda function: ${functionName}`);
+      try {
+        execSync(
+          `aws lambda update-function-code --function-name ${functionName} --zip-file fileb://${zipPath}`,
+          { stdio: 'inherit' }
+        );
+
+        if (await waitForLambdaUpdate(functionName)) {
+          try {
+            execSync(
+              `aws lambda update-function-configuration --function-name ${functionName} ` +
+                `--timeout ${LAMBDA_CONFIG.timeout} --memory-size ${LAMBDA_CONFIG.memorySize} ` +
+                `--environment "${envFileArg}"`,
+              { stdio: 'inherit' }
+            );
+          } catch (configError) {
+            if (configError.message.includes('ResourceConflictException')) {
+              console.log(
+                `⚠️ Configuration update skipped for ${functionName} - update still in progress`
+              );
+            } else {
+              throw configError;
+            }
           }
         }
+      } catch (codeError) {
+        if (codeError.message.includes('ResourceConflictException')) {
+          console.log(`⚠️ Code update skipped for ${functionName} - update already in progress`);
+        } else {
+          throw codeError;
+        }
       }
-    } catch (codeError) {
-      if (codeError.message.includes('ResourceConflictException')) {
-        console.log(`⚠️ Code update skipped for ${functionName} - update already in progress`);
-      } else {
-        throw codeError;
-      }
+    } else {
+      console.log(`Creating Lambda function: ${functionName}`);
+      execSync(
+        `aws lambda create-function --function-name ${functionName} ` +
+          `--runtime ${LAMBDA_CONFIG.runtime} ` +
+          `--role ${roleArn} ` +
+          `--handler index.handler ` +
+          `--zip-file fileb://${zipPath} ` +
+          `--timeout ${LAMBDA_CONFIG.timeout} ` +
+          `--memory-size ${LAMBDA_CONFIG.memorySize} ` +
+          `--environment "${envFileArg}"`,
+        { stdio: 'inherit' }
+      );
     }
-  } else {
-    // Create new function
-    console.log(`Creating Lambda function: ${functionName}`);
-    execSync(
-      `aws lambda create-function --function-name ${functionName} ` +
-      `--runtime ${LAMBDA_CONFIG.runtime} ` +
-      `--role ${roleArn} ` +
-      `--handler index.handler ` +
-      `--zip-file fileb://${zipPath} ` +
-      `--timeout ${LAMBDA_CONFIG.timeout} ` +
-      `--memory-size ${LAMBDA_CONFIG.memorySize} ` +
-      `--environment "Variables={STAGE=${STAGE}}"`,
-      { stdio: 'inherit' }
-    );
+
+    console.log(`✅ Deployed ${functionName}`);
+    return functionName;
+  } finally {
+    removeLambdaEnvironmentFile(handlerName);
   }
-  
-  console.log(`✅ Deployed ${functionName}`);
-  return functionName;
 }
 
 async function deployAllLambdas() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deployed Playwright regression calls `/api/auth/e2e-login`, which requires `E2E_AUTH_ENABLED` and `E2E_AUTH_SECRET` on Lambdas. `deploy-lambdas.js` previously set only `STAGE`, so e2e-login stayed disabled in AWS.

## Changes

- **`scripts/deploy-lambdas.js`**: Build Lambda environment from JSON and pass `--environment file://…`. One file per handler for `--parallel` and safe secret handling.
- **`.github/workflows/deploy-fullstack.yml`**: Set `E2E_AUTH_ENABLED` when **`env.STAGE == 'dev'`** (same rule as the workflow: prerelease tags contain a hyphen, e.g. `v0.0.12-beta.0`). Production tags (`v1.0.0`-style) keep E2E off Lambdas. This replaces an earlier “non-tag push” check, which became wrong after deploy moved to **tag-only** triggers—every deploy is `refs/tags/v…`, so that expression would have disabled E2E always.
- **`.github/workflows/e2e-deployed-after-develop-deploy.yml`**: Remove `branches: [develop]` on `workflow_run` (tag deploys use `head_branch` like `v0.0.12-beta.1`, not `develop`). Gate the job with the same dev heuristic: `head_branch == 'develop'` **or** `contains(head_branch, '-')` (prerelease tag), so production tag deploys still skip this workflow.
- **`.gitignore`**: `lambda-deploy-environment-*.json`

## After merge

Run a **dev** deploy (prerelease tag path) so Lambdas pick up E2E env. Ensure the **development** environment defines `E2E_AUTH_SECRET`. Set `E2E_DEV_*` URLs with a scheme (`https://…`).

Branch includes **`origin/develop` merged** so this stays consistent with tag-based deploy + pre-release versioning.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-096c60d8-9224-4f21-9dd7-ce6ee63218f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-096c60d8-9224-4f21-9dd7-ce6ee63218f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

