### PR TITLE
fix(deploy): dev E2E seed data and two-phase S3 sync for SPA

### DIFF
--- a/.github/workflows/deploy-fullstack.yml
+++ b/.github/workflows/deploy-fullstack.yml
@@ -205,6 +205,14 @@ jobs:
           node scripts/create-dynamodb-tables.js
           node scripts/deployment-status-tracker.js track dynamodb success
 
+      # Deployed Playwright core regression expects org-e2e-main / prod-bulk-helmet / etc. in dev DynamoDB.
+      - name: Seed E2E fixture data (dev only)
+        if: ${{ steps.scope.outputs.deploy_backend == 'true' && env.STAGE == 'dev' }}
+        run: |
+          node scripts/deployment-status-tracker.js track seed-e2e started
+          node scripts/seed-e2e-data.js
+          node scripts/deployment-status-tracker.js track seed-e2e success
+
       - name: Create Lambda deployment packages
         id: create-lambda-packages
         if: steps.scope.outputs.deploy_backend == 'true'

--- a/scripts/deploy-frontend-fast.js
+++ b/scripts/deploy-frontend-fast.js
@@ -51,34 +51,43 @@ function deployToS3(bucketName) {
   console.log(`📦 Deploying to S3 bucket: ${bucketName}...`);
   
   const startTime = Date.now();
-  
-  // Upload hashed static assets with long-term caching and immutable flag
+
+  // Two-phase sync avoids a race where --delete removes old hashed bundles while
+  // index.html still references them (S3 website ErrorDocument serves HTML for 404 JS → MIME errors).
+  const immutableExclude =
+    '--exclude "*.html" --exclude "*.xml" --exclude "*.txt"';
+
+  // 1) Upload new hashed assets; keep prior bundles until HTML is updated.
   execSync(
-    `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --delete --exclude "*.html" --exclude "*.xml" --exclude "*.txt" --cache-control "max-age=31536000,immutable"`,
+    `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ ${immutableExclude} --cache-control "max-age=31536000,immutable"`,
     { stdio: 'inherit' }
   );
-  
-  // Upload HTML files with strict no-cache headers
+
+  // 2) Publish fresh index.html (and any other HTML).
   execSync(
     `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --exclude "*" --include "*.html" --cache-control "no-cache,no-store,must-revalidate"`,
     { stdio: 'inherit' }
   );
-  
-  // Upload translation files with very short cache (these change frequently)
+
+  // 3) Translations and static assets (cache tiers).
   execSync(
     `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --exclude "*" --include "assets/i18n/*" --cache-control "max-age=300"`,
     { stdio: 'inherit' }
   );
-  
-  // Upload other asset files (images, icons) with medium cache
+
   execSync(
     `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --exclude "*" --include "assets/*" --exclude "assets/i18n/*" --cache-control "max-age=3600"`,
     { stdio: 'inherit' }
   );
-  
-  // Upload other non-hashed files with short cache
+
   execSync(
     `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --exclude "*" --include "*.xml" --include "*.txt" --cache-control "max-age=3600"`,
+    { stdio: 'inherit' }
+  );
+
+  // 4) Remove obsolete hashed files now that index points at the new bundles.
+  execSync(
+    `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --delete ${immutableExclude} --cache-control "max-age=31536000,immutable"`,
     { stdio: 'inherit' }
   );
   

--- a/scripts/deploy-frontend.js
+++ b/scripts/deploy-frontend.js
@@ -99,33 +99,38 @@ function uploadToS3(bucketName) {
     throw new Error(`Frontend build directory not found: ${FRONTEND_DIST_PATH}`);
   }
   
-  // Upload hashed static assets with long-term caching
+  // Two-phase sync: upload new bundles before --delete so stale index.html never
+  // references JS that was already removed (S3 website 404 → index.html → module MIME errors).
+  const immutableExclude =
+    '--exclude "*.html" --exclude "*.xml" --exclude "*.txt"';
+
   execSync(
-    `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --delete --exclude "*.html" --exclude "*.xml" --exclude "*.txt" --cache-control "max-age=31536000,immutable"`,
+    `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ ${immutableExclude} --cache-control "max-age=31536000,immutable"`,
     { stdio: 'inherit' }
   );
-  
-  // Upload HTML files with no-cache headers
+
   execSync(
     `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --exclude "*" --include "*.html" --cache-control "no-cache,no-store,must-revalidate"`,
     { stdio: 'inherit' }
   );
-  
-  // Upload translation files with short cache (these change frequently)
+
   execSync(
     `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --exclude "*" --include "assets/i18n/*" --cache-control "max-age=300"`,
     { stdio: 'inherit' }
   );
-  
-  // Upload other asset files (images, icons) with medium cache
+
   execSync(
     `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --exclude "*" --include "assets/*" --exclude "assets/i18n/*" --cache-control "max-age=3600"`,
     { stdio: 'inherit' }
   );
-  
-  // Upload other non-hashed files (robots.txt, sitemap.xml, etc.) with short cache
+
   execSync(
     `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --exclude "*" --include "*.xml" --include "*.txt" --cache-control "max-age=3600"`,
+    { stdio: 'inherit' }
+  );
+
+  execSync(
+    `aws s3 sync ${FRONTEND_DIST_PATH} s3://${bucketName}/ --delete ${immutableExclude} --cache-control "max-age=31536000,immutable"`,
     { stdio: 'inherit' }
   );
   

--- a/scripts/deployment-status-tracker.js
+++ b/scripts/deployment-status-tracker.js
@@ -23,7 +23,8 @@ const DEPLOYMENT_STEPS = {
   'frontend-fast': 'Deploy Frontend (Fast)',
   'frontend-full': 'Deploy Frontend (Full setup)',
   'cloudfront': 'Create CloudFront Distribution',
-  'custom-domain': 'Setup Custom Domain'
+  'custom-domain': 'Setup Custom Domain',
+  'seed-e2e': 'Seed E2E fixture data (dev)'
 };
 
 function loadDeploymentInfo() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the post-deploy break reported after the `v0.0.12-beta.2` full-stack deploy run.

### Deployed core regression (`gh run view 23406901577 --log-failed`)

Failures were `Missing inventory item for product prod-bulk-helmet` in `core-regression.spec.ts`. After #73, E2E JWT minting works against dev, but **dev DynamoDB was never seeded** with `scripts/seed-e2e-data.js` (that only ran via LocalStack setup). The API returned real inventory without the E2E fixtures.

**Change:** After `create-dynamodb-tables`, when `STAGE` is `dev` and the backend deploys, run `node scripts/seed-e2e-data.js` (idempotent `PutCommand`s).

### Frontend MIME / module script error

S3 static website uses `ErrorDocument: index.html`. The fast deploy did `aws s3 sync --delete` **before** uploading the new `index.html`, so old hashed chunks could be removed while CDN/clients still had the previous HTML. Requests for those `.js` URLs 404 and return **HTML**, which triggers strict ES module MIME checking.

**Change:** Two-phase sync in `deploy-frontend-fast.js` and `deploy-frontend.js`: upload immutable bundles **without** `--delete`, publish HTML and other assets, then run `sync --delete` for the same exclude set to drop orphans.

## Verification

- `curl` against `https://dev.equip-track.com/main.js` already returns `text/javascript`; the ordering fix prevents the transient broken window on future deploys.
- After merge + next dev tag deploy, seeded data should satisfy deployed Playwright `core-regression.spec.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56977862-c7bb-4f09-8afb-8bf49a5eef73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56977862-c7bb-4f09-8afb-8bf49a5eef73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

