### PR TITLE
fix(ci): Nx Cloud remote cache for tag deploy frontend/backend builds

### DIFF
--- a/.github/workflows/deploy-fullstack.yml
+++ b/.github/workflows/deploy-fullstack.yml
@@ -18,6 +18,10 @@ env:
   STAGE: ${{ contains(github.ref, '-') && 'dev' || 'production' }}
   # Optional: set repository secret NX_CLOUD_ACCESS_TOKEN after `nx connect` for remote cache.
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  # Tag pushes report refs/tags/* as the branch in CI metadata; Nx Cloud uses that for cache partitioning,
+  # so deploy jobs would not reuse remote cache from the default-branch pipeline. Pin to the repo default
+  # branch so nx build (frontend/backend) shares the same Nx Cloud cache as develop/main CI and local runs.
+  NX_BRANCH: ${{ github.event.repository.default_branch || 'develop' }}
 
 jobs:
   deploy:
@@ -167,7 +171,7 @@ jobs:
             echo "- **Skip API Gateway (~10+ min)** when \`deploy_api_gateway\` is \`false\`: backend deploys but \`libs/shared/src/api/\` and gateway/prepare scripts did not change since base SHA, and an API already exists in AWS."
             echo "- **Skip one app build** when only frontend or only backend is affected (not both)."
             echo "- **Shared library:** almost any change under \`libs/shared\` marks **both** apps affected (both import it), so many real commits still build and deploy both."
-            echo "- **Nx Cloud:** add \`NX_CLOUD_ACCESS_TOKEN\` to shorten \`nx build\` when cache hits."
+            echo "- **Nx Cloud:** set \`NX_CLOUD_ACCESS_TOKEN\` (repo secret) for remote cache; this workflow sets \`NX_BRANCH\` to the default branch on tag deploys so cache matches merge CI."
             echo "- **Lambda packaging** uses one \`npm install\` for all handler zips; zipping every function still takes time."
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/nx.json
+++ b/nx.json
@@ -13,7 +13,6 @@
       "!{projectRoot}/test-setup.[jt]s"
     ],
     "sharedGlobals": [
-      "{workspaceRoot}/.github/workflows/ci.yml",
       "{workspaceRoot}/.github/workflows/deploy-fullstack.yml"
     ]
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy Full Stack runs on `refs/tags/v*` pushes. Nx Cloud was treating the branch metadata as the tag ref, which **partitions remote cache** away from the default-branch pipeline (e.g. `develop`). As a result, `nx build frontend` (and backend) on deploy often missed remote cache even when the same sources were already built on the default branch.

## Changes

- Set `NX_BRANCH` to `github.event.repository.default_branch` (fallback `develop`) in `deploy-fullstack.yml` so tag deploy builds reuse the same Nx Cloud cache namespace as merge CI and typical local runs.
- Remove a non-existent `.github/workflows/ci.yml` entry from `nx.json` `sharedGlobals` so named inputs stay consistent.

## Notes

- Continue to provide `NX_CLOUD_ACCESS_TOKEN` as a repository secret for read/write remote cache in CI.
- After merge, the **first** tag deploy may still be a cache miss; subsequent deploys with unchanged build inputs should see remote hits aligned with default-branch history.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10551ec2-446e-4be1-8394-692f4302739d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10551ec2-446e-4be1-8394-692f4302739d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

