### PR TITLE
fix(frontend): keep top bar visible while scrolling

### DIFF
--- a/apps/frontend/src/ui/side-nav/side-nav.component.scss
+++ b/apps/frontend/src/ui/side-nav/side-nav.component.scss
@@ -54,13 +54,22 @@
         }
     }
 
-    mat-sidenav-content {
+    // Element + class beats Material's `.mat-drawer-content { overflow: auto }` so only `.content` scrolls.
+    mat-sidenav-content.mat-drawer-content {
         background-color: var(--color-bg-primary);
         height: 100%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    top-bar {
+        flex-shrink: 0;
     }
 
     .content {
-        height: 100%;
+        flex: 1 1 auto;
+        min-height: 0;
         overflow: auto;
         margin: 24px;
     }

--- a/apps/frontend/src/ui/top-bar/top-bar.component.scss
+++ b/apps/frontend/src/ui/top-bar/top-bar.component.scss
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  flex-shrink: 0;
+}
+
 .top-bar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The main area used `height: 100%` next to the top bar inside `mat-sidenav-content`. Together with Angular Material’s `.mat-drawer-content { overflow: auto }`, the whole column (toolbar + content) became one scroll region, so the top bar scrolled away.

## Changes

- Make `mat-sidenav-content` a column flex container with `overflow: hidden`, using `mat-sidenav-content.mat-drawer-content` so we override Material’s `overflow: auto`.
- Scroll only inside `.content` via `flex: 1`, `min-height: 0`, and `overflow: auto`.
- Give `top-bar` a non-shrinking host (`flex-shrink: 0`) for a stable flex layout.

## Testing

- `nx run frontend:lint`
- `nx run frontend:test --testPathPattern=top-bar`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8c3f5da-a59c-46fc-b416-7163c9176f62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8c3f5da-a59c-46fc-b416-7163c9176f62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

