### PR TITLE
fix(inventory): limit UPI fields to 100 per line item

### DIFF
--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -238,6 +238,7 @@
       "quantity-required": "Quantity is required",
       "quantity-min": "Quantity must be at least 1",
       "quantity-pattern": "Quantity must be a valid number",
+      "quantity-max-upi": "At most {{max}} UPI fields can be added per item",
       "upi-required": "UPI is required",
       "upi-duplicate": "UPI must be unique",
       "product-not-found": "Product not found in source",

--- a/apps/frontend/src/assets/i18n/he.json
+++ b/apps/frontend/src/assets/i18n/he.json
@@ -237,6 +237,7 @@
       "quantity-required": "נדרשת כמות",
       "quantity-min": "הכמות חייבת להיות לפחות 1",
       "quantity-pattern": "הכמות חייבת להיות מספר תקין",
+      "quantity-max-upi": "ניתן להוסיף עד {{max}} שדות צ׳ לפריט",
       "upi-required": "נדרש צ׳",
       "upi-duplicate": "צ׳ חייב להיות ייחודי",
       "product-not-found": "המוצר לא נמצא במקור",

--- a/apps/frontend/src/ui/inventory/edit/item/editable-item.component.html
+++ b/apps/frontend/src/ui/inventory/edit/item/editable-item.component.html
@@ -42,6 +42,7 @@
       [formControl]="quantityControl()"
       type="number"
       min="1"
+      [attr.max]="isUPI() ? maxUpiQuantity : null"
       data-testid="editable-item-quantity-input"
     />
     @if (quantityErrors()['required']) {
@@ -52,6 +53,11 @@
     }
     @else if (quantityErrors()['pattern']) {
       <mat-error>{{ 'inventory.validation.quantity-pattern' | translate }}</mat-error>
+    }
+    @else if (quantityErrors()['max']) {
+      <mat-error>{{
+        'inventory.validation.quantity-max-upi' | translate : { max: maxUpiQuantity }
+      }}</mat-error>
     }
   </mat-form-field>
   

--- a/apps/frontend/src/ui/inventory/edit/item/editable-item.component.spec.ts
+++ b/apps/frontend/src/ui/inventory/edit/item/editable-item.component.spec.ts
@@ -1,11 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
+import { FormBuilder, ValidatorFn } from '@angular/forms';
 import { EditableItemComponent } from './editable-item.component';
+import { OrganizationStore } from '../../../../store';
+import { emptyItem } from '../form.mudels';
 
 describe('EditableItemComponent', () => {
   let component: EditableItemComponent;
   let fixture: ComponentFixture<EditableItemComponent>;
+  let fb: FormBuilder;
+  const noopLimit: ValidatorFn = () => null;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -16,12 +22,63 @@ describe('EditableItemComponent', () => {
       ],
     }).compileComponents();
 
+    fb = TestBed.inject(FormBuilder);
+    const store = TestBed.inject(OrganizationStore);
+    store.setProducts([
+      { id: 'upi-prod', name: 'Serial tracked', hasUpi: true },
+      { id: 'bulk-prod', name: 'Bulk', hasUpi: false },
+    ]);
+
     fixture = TestBed.createComponent(EditableItemComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('control', emptyItem(fb, noopLimit));
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should cap UPI form fields at MAX_UPI_QUANTITY when quantity is huge', () => {
+    component.productIdControl().setValue('upi-prod');
+    fixture.detectChanges();
+
+    component.quantityControl().setValue(10_000);
+    fixture.detectChanges();
+
+    expect(component.upisControl().length).toBe(
+      EditableItemComponent.MAX_UPI_QUANTITY
+    );
+    expect(component.quantityControl().value).toBe(
+      EditableItemComponent.MAX_UPI_QUANTITY
+    );
+  });
+
+  it('should not grow the upis array for non-UPI products when quantity is large', () => {
+    component.productIdControl().setValue('bulk-prod');
+    fixture.detectChanges();
+
+    const before = component.upisControl().length;
+    component.quantityControl().setValue(5000);
+    fixture.detectChanges();
+
+    expect(component.upisControl().length).toBe(before);
+    expect(component.quantityControl().value).toBe(5000);
+  });
+
+  it('should not add another UPI row when already at the limit', () => {
+    component.productIdControl().setValue('upi-prod');
+    fixture.detectChanges();
+    component.quantityControl().setValue(EditableItemComponent.MAX_UPI_QUANTITY);
+    fixture.detectChanges();
+
+    const len = component.upisControl().length;
+    const addBtn = fixture.debugElement.query(
+      By.css('[data-testid="editable-item-add-upi"]')
+    );
+    addBtn.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.upisControl().length).toBe(len);
   });
 });

--- a/apps/frontend/src/ui/inventory/edit/item/editable-item.component.ts
+++ b/apps/frontend/src/ui/inventory/edit/item/editable-item.component.ts
@@ -35,7 +35,15 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { first, map, distinctUntilChanged, filter, Subscription } from 'rxjs';
+import {
+  first,
+  map,
+  distinctUntilChanged,
+  filter,
+  Subscription,
+  merge,
+  of,
+} from 'rxjs';
 import { toObservable } from '@angular/core/rxjs-interop';
 
 @UntilDestroy()
@@ -57,6 +65,13 @@ import { toObservable } from '@angular/core/rxjs-interop';
   styleUrl: './editable-item.component.scss',
 })
 export class EditableItemComponent implements OnInit {
+  /** Max UPI fields per line item — avoids freezing the UI on huge quantities. */
+  static readonly MAX_UPI_QUANTITY = 100;
+
+  private readonly maxUpiQuantityValidator = Validators.max(
+    EditableItemComponent.MAX_UPI_QUANTITY
+  );
+
   fb = inject(FormBuilder);
   organizationStore = inject(OrganizationStore);
   control = input<FormGroup<FormInventoryItem>>(emptyItem(this.fb, () => null));
@@ -79,6 +94,7 @@ export class EditableItemComponent implements OnInit {
   });
 
   constructor() {
+    this.syncUpiQuantityMaxValidator();
     this.initialResizeUPIs();
     this.initialProductIdSignal();
     this.initialSearchTerm();
@@ -116,6 +132,9 @@ export class EditableItemComponent implements OnInit {
 
   isUPI: Signal<boolean> = computed(() => this.product()?.hasUpi ?? false);
 
+  /** Exposed for template (max UPI fields per row). */
+  protected readonly maxUpiQuantity = EditableItemComponent.MAX_UPI_QUANTITY;
+
   @HostBinding('class.upi-item')
   get isUpiItem(): boolean {
     return this.isUPI();
@@ -149,6 +168,19 @@ export class EditableItemComponent implements OnInit {
   }
 
   private quantitySubscription: Subscription | null = null;
+  private upisLengthSubscription: Subscription | null = null;
+
+  private syncUpiQuantityMaxValidator() {
+    effect(() => {
+      const qc = this.quantityControl();
+      qc.removeValidators(this.maxUpiQuantityValidator);
+      if (this.isUPI()) {
+        qc.addValidators(this.maxUpiQuantityValidator);
+      }
+      qc.updateValueAndValidity({ emitEvent: false });
+    });
+  }
+
   private initialResizeUPIs() {
     effect(() => {
       const quantityControl = this.quantityControl();
@@ -160,33 +192,61 @@ export class EditableItemComponent implements OnInit {
         return;
       }
       this.quantitySubscription?.unsubscribe();
-      this.quantitySubscription = quantityControl.valueChanges.subscribe(
-        (value) => {
-          if (value === null) return;
+      this.quantitySubscription = merge(
+        of(quantityControl.value),
+        quantityControl.valueChanges
+      ).subscribe((raw) => {
+        if (raw === null) return;
+        const value = typeof raw === 'number' && Number.isNaN(raw) ? null : raw;
+        if (value === null) return;
 
-          if (value < 0) {
-            quantityControl.setValue(0, { emitEvent: false });
-            value = 0;
-          }
+        let qty = value;
+        if (qty < 0) {
+          quantityControl.setValue(0, { emitEvent: false });
+          qty = 0;
+        }
 
-          while (upisControl.length < value) {
-            this.addUpi(false);
-          }
+        if (this.isUPI() && qty > EditableItemComponent.MAX_UPI_QUANTITY) {
+          qty = EditableItemComponent.MAX_UPI_QUANTITY;
+          quantityControl.setValue(qty, { emitEvent: false });
+        }
 
-          while (upisControl.length > value) {
-            if (!this.removeEmptyUpi()) {
-              break;
-            }
-          }
+        if (!this.isUPI()) {
+          return;
+        }
 
-          if (upisControl.length > value) {
-            quantityControl.setValue(upisControl.length, { emitEvent: false });
+        while (upisControl.length < qty) {
+          this.addUpi(false);
+        }
+
+        while (upisControl.length > qty) {
+          if (!this.removeEmptyUpi()) {
+            break;
           }
         }
-      );
 
-      upisControl.valueChanges
+        if (upisControl.length > EditableItemComponent.MAX_UPI_QUANTITY) {
+          while (
+            upisControl.length > EditableItemComponent.MAX_UPI_QUANTITY
+          ) {
+            upisControl.removeAt(upisControl.length - 1, { emitEvent: false });
+          }
+          quantityControl.setValue(
+            EditableItemComponent.MAX_UPI_QUANTITY,
+            { emitEvent: false }
+          );
+          qty = EditableItemComponent.MAX_UPI_QUANTITY;
+        }
+
+        if (upisControl.length > qty) {
+          quantityControl.setValue(upisControl.length, { emitEvent: false });
+        }
+      });
+
+      this.upisLengthSubscription?.unsubscribe();
+      this.upisLengthSubscription = upisControl.valueChanges
         .pipe(
+          filter(() => this.isUPI()),
           filter((value) => value !== null),
           map((value) => value.length),
           distinctUntilChanged()
@@ -275,6 +335,12 @@ export class EditableItemComponent implements OnInit {
   }
 
   protected addUpi(emitEvent = true) {
+    if (
+      this.isUPI() &&
+      this.upisControl().length >= EditableItemComponent.MAX_UPI_QUANTITY
+    ) {
+      return -1;
+    }
     const control = new FormControl('');
     const newIndex = this.upisControl().length;
     this.setUPIValidations(control, newIndex);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Caps serial-tracked (UPI) inventory rows at **100** UPI input fields so entering a huge quantity no longer freezes the browser.
- Adds `Validators.max(100)` when the selected product uses UPIs, `max` on the quantity input, and translated validation copy (en/he).
- Skips resizing the hidden `upis` `FormArray` from quantity when the product is **not** UPI-tracked, so large bulk quantities no longer allocate thousands of controls.
- Trims excess UPI controls if a row ever exceeds the cap (e.g. stale state).

## Testing
- `nx test frontend --testFile=editable-item.component.spec.ts`

Closes #57
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82d7b7a8-1e5d-4362-8cf1-faa423dd1727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82d7b7a8-1e5d-4362-8cf1-faa423dd1727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

