### PR TITLE
fix(ci): serialize full-stack AWS deploy per stage (dev vs production)

### DIFF
--- a/.github/workflows/deploy-fullstack.yml
+++ b/.github/workflows/deploy-fullstack.yml
@@ -5,9 +5,10 @@ on:
     tags:
       - 'v*'
 
-# One deploy at a time per ref avoids S3 sync --delete races and CloudFront ETag conflicts.
+# One deploy at a time per AWS stage (not per tag ref). Prerelease tags share the same target as dev;
+# using github.ref per tag allowed v1.0.0-beta.1 and v1.0.0-beta.2 to run in parallel and race S3/CloudFront.
 concurrency:
-  group: deploy-fullstack-${{ github.ref }}
+  group: deploy-fullstack-${{ contains(github.ref, '-') && 'dev' || 'production' }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Deploy Full Stack to AWS** workflow used `concurrency.group: deploy-fullstack-${{ github.ref }}`, so each tag had its own queue. Multiple prerelease tags (e.g. `v1.0.0-beta.1` and `v1.0.0-beta.2`) all deploy to **dev** but could run **at the same time**, reproducing S3 sync and CloudFront races.

## Change

Use the same **stage** discriminator already used for `STAGE` and the GitHub Environment: `contains(github.ref, '-')` → **dev**, else **production**. Concurrency groups are now:

- `deploy-fullstack-dev` — all prerelease tags share one queue  
- `deploy-fullstack-production` — all stable release tags share one queue  

`cancel-in-progress` remains `false` so in-flight deploys are not cancelled.

## Alternative considered

A single global group would block dev and production from ever overlapping; stage-scoped groups keep that separation while fixing same-environment parallelism.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33c29aae-cf7b-448a-a27e-ee883185fc24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33c29aae-cf7b-448a-a27e-ee883185fc24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

