### PR TITLE
Allow http://localhost:4200 in dev backend CORS (deploy + Lambda)

### DIFF
--- a/apps/backend/src/api/cors.spec.ts
+++ b/apps/backend/src/api/cors.spec.ts
@@ -1,0 +1,35 @@
+describe('cors (dev deploy localhost:4200)', () => {
+  const originalStage = process.env.STAGE;
+
+  afterEach(() => {
+    process.env.STAGE = originalStage;
+    jest.resetModules();
+  });
+
+  it('production keeps wildcard origin', () => {
+    process.env.STAGE = 'production';
+    const { resolveAccessControlAllowOrigin } = require('./cors');
+    expect(resolveAccessControlAllowOrigin('http://localhost:4200')).toBe('*');
+  });
+
+  it('dev echoes localhost:4200 when Origin matches (with or without trailing slash)', () => {
+    process.env.STAGE = 'dev';
+    const { resolveAccessControlAllowOrigin, buildCorsHeaders } = require('./cors');
+    expect(resolveAccessControlAllowOrigin('http://localhost:4200')).toBe(
+      'http://localhost:4200'
+    );
+    expect(resolveAccessControlAllowOrigin('http://localhost:4200/')).toBe(
+      'http://localhost:4200'
+    );
+    expect(
+      buildCorsHeaders('http://localhost:4200')['Access-Control-Allow-Origin']
+    ).toBe('http://localhost:4200');
+  });
+
+  it('dev uses wildcard for other origins', () => {
+    process.env.STAGE = 'dev';
+    const { resolveAccessControlAllowOrigin } = require('./cors');
+    expect(resolveAccessControlAllowOrigin('https://dev.equip-track.com')).toBe('*');
+    expect(resolveAccessControlAllowOrigin(undefined)).toBe('*');
+  });
+});

--- a/apps/backend/src/api/cors.ts
+++ b/apps/backend/src/api/cors.ts
@@ -1,0 +1,49 @@
+/**
+ * Dev deploy (STAGE !== production): echo http://localhost:4200 when the browser
+ * sends that Origin so CORS stays valid alongside API Gateway / strict clients.
+ * Production and other origins continue to use '*'.
+ */
+const STAGE = process.env.STAGE || 'dev';
+const IS_PRODUCTION = STAGE === 'production';
+
+const LOCAL_ANGULAR_DEV_ORIGIN = 'http://localhost:4200';
+
+const CORS_ALLOW_HEADERS =
+  'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Accept,Origin,X-Requested-With';
+
+function normalizeOriginForCompare(origin: string): string {
+  return origin.trim().replace(/\/+$/, '');
+}
+
+export function getRequestOrigin(
+  headers: Record<string, string | undefined> | null | undefined
+): string | undefined {
+  if (!headers) return undefined;
+  const raw = headers['Origin'] ?? headers['origin'];
+  if (typeof raw !== 'string' || !raw.trim()) return undefined;
+  return raw;
+}
+
+export function resolveAccessControlAllowOrigin(
+  requestOrigin: string | undefined
+): string {
+  if (IS_PRODUCTION || !requestOrigin) {
+    return '*';
+  }
+  if (normalizeOriginForCompare(requestOrigin) === LOCAL_ANGULAR_DEV_ORIGIN) {
+    return LOCAL_ANGULAR_DEV_ORIGIN;
+  }
+  return '*';
+}
+
+export function buildCorsHeaders(
+  requestOrigin: string | undefined
+): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': resolveAccessControlAllowOrigin(requestOrigin),
+    'Access-Control-Allow-Headers': CORS_ALLOW_HEADERS,
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Credentials': 'false',
+    'Content-Type': 'application/json',
+  };
+}

--- a/apps/backend/src/api/handler-factory.ts
+++ b/apps/backend/src/api/handler-factory.ts
@@ -10,11 +10,11 @@ import {
   OptionalObject,
 } from '@equip-track/shared';
 import { HandlerFunction, handlers } from './handlers';
+import { buildCorsHeaders, getRequestOrigin } from './cors';
 import {
   ErrorResponse,
   unauthorized,
   internalServerError,
-  CORS_HEADERS,
 } from './responses';
 import { authenticateAndGetJwt } from './auth';
 
@@ -35,6 +35,7 @@ export function createLambdaHandler<
   handler: HandlerFunction<Req, Res>
 ): APIGatewayProxyHandler {
   return async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const corsHeaders = buildCorsHeaders(getRequestOrigin(event.headers));
     try {
       console.log(`[${meta.path}] Processing request`, {
         method: meta.method,
@@ -72,7 +73,7 @@ export function createLambdaHandler<
 
       return {
         statusCode: 200,
-        headers: CORS_HEADERS,
+        headers: corsHeaders,
         body: JSON.stringify(result),
       };
     } catch (error) {
@@ -85,15 +86,19 @@ export function createLambdaHandler<
         return {
           statusCode: errorResponse.statusCode,
           headers: {
-            ...CORS_HEADERS,
             ...errorResponse.headers,
+            ...corsHeaders,
           },
           body: errorResponse.body,
         };
       }
 
       console.log(`[${meta.path}] Creating generic error response for:`, error);
-      return internalServerError(error?.message || 'Internal server error');
+      const err = internalServerError(error?.message || 'Internal server error');
+      return {
+        ...err,
+        headers: { ...err.headers, ...corsHeaders },
+      };
     }
   };
 }

--- a/apps/backend/src/local-http-server.ts
+++ b/apps/backend/src/local-http-server.ts
@@ -1,4 +1,9 @@
-import { IncomingMessage, ServerResponse, createServer } from 'http';
+import {
+  IncomingMessage,
+  OutgoingHttpHeaders,
+  ServerResponse,
+  createServer,
+} from 'http';
 import {
   APIGatewayProxyEvent,
   APIGatewayProxyHandler,
@@ -6,7 +11,7 @@ import {
 } from 'aws-lambda';
 import { endpointMetas } from '@equip-track/shared';
 import { lambdaHandlers } from './api/handler-factory';
-import { CORS_HEADERS } from './api/responses';
+import { buildCorsHeaders, getRequestOrigin } from './api/cors';
 
 interface CompiledRoute {
   endpointKey: keyof typeof endpointMetas;
@@ -153,14 +158,19 @@ function createApiGatewayEvent(
   };
 }
 
+function corsHeadersForRequest(req: IncomingMessage): Record<string, string> {
+  return buildCorsHeaders(getRequestOrigin(normalizeHeaders(req.headers)));
+}
+
 function sendJsonResponse(
   res: ServerResponse,
+  req: IncomingMessage,
   statusCode: number,
   body: unknown,
   headers: Record<string, string> = {}
 ): void {
   res.writeHead(statusCode, {
-    ...CORS_HEADERS,
+    ...corsHeadersForRequest(req),
     ...headers,
   });
   res.end(typeof body === 'string' ? body : JSON.stringify(body));
@@ -207,18 +217,18 @@ export async function startLocalHttpServer(): Promise<void> {
     const pathname = url.pathname;
 
     if (method === 'OPTIONS') {
-      sendJsonResponse(res, 200, '');
+      sendJsonResponse(res, req, 200, '');
       return;
     }
 
     if (method === 'GET' && pathname === '/health') {
-      sendJsonResponse(res, 200, { status: 'ok' });
+      sendJsonResponse(res, req, 200, { status: 'ok' });
       return;
     }
 
     const match = findRoute(method, pathname);
     if (!match) {
-      sendJsonResponse(res, 404, {
+      sendJsonResponse(res, req, 404, {
         status: false,
         error: 'Not Found',
         path: pathname,
@@ -233,14 +243,15 @@ export async function startLocalHttpServer(): Promise<void> {
       const event = createApiGatewayEvent(req, pathname, body, match.pathParameters);
       const result = await invokeLambdaHandler(handler, event);
 
-      res.writeHead(result.statusCode, {
-        ...CORS_HEADERS,
+      const mergedHeaders = {
         ...(result.headers || {}),
-      });
+        ...corsHeadersForRequest(req),
+      } as OutgoingHttpHeaders;
+      res.writeHead(result.statusCode, mergedHeaders);
       res.end(result.body || '');
     } catch (error) {
       console.error('[local-http-server] request failed:', error);
-      sendJsonResponse(res, 500, {
+      sendJsonResponse(res, req, 500, {
         status: false,
         error: 'Internal server error',
       });

--- a/infra/sam/template.yaml
+++ b/infra/sam/template.yaml
@@ -32,6 +32,10 @@ Conditions:
           - Fn::Equals:
               - !Ref ApiHostname
               - ''
+  IsProductionStage:
+    Fn::Equals:
+      - !Ref Stage
+      - production
 Resources:
   EquipTrackApi:
     Type: AWS::Serverless::Api
@@ -42,7 +46,7 @@ Resources:
       Cors:
         AllowMethods: "'GET,POST,PUT,DELETE,OPTIONS'"
         AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Accept,Origin,X-Requested-With'"
-        AllowOrigin: "'*'"
+        AllowOrigin: !If [IsProductionStage, "'*'", "'http://localhost:4200,*'"]
         AllowCredentials: false
         MaxAge: "'86400'"
       DefinitionBody:

--- a/scripts/generate-sam-template.js
+++ b/scripts/generate-sam-template.js
@@ -126,6 +126,10 @@ Conditions:
           - Fn::Equals:
               - !Ref ApiHostname
               - ''
+  IsProductionStage:
+    Fn::Equals:
+      - !Ref Stage
+      - production
 Resources:
   EquipTrackApi:
     Type: AWS::Serverless::Api
@@ -136,7 +140,7 @@ Resources:
       Cors:
         AllowMethods: "'GET,POST,PUT,DELETE,OPTIONS'"
         AllowHeaders: "'${CORS_HEADERS}'"
-        AllowOrigin: "'*'"
+        AllowOrigin: !If [IsProductionStage, "'*'", "'http://localhost:4200,*'"]
         AllowCredentials: false
         MaxAge: "'86400'"
       DefinitionBody:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Lambda responses:** For non-production `STAGE`, when the request sends `Origin: http://localhost:4200` (trailing slash tolerated), responses use `Access-Control-Allow-Origin: http://localhost:4200` instead of `*`, so strict CORS checks against the deployed dev API work for the Angular dev server. Production behavior stays `*`.
- **API Gateway (SAM):** Dev stacks set `Cors.AllowOrigin` to `http://localhost:4200,*` via CloudFormation `!If` on `Stage`; production remains `*` only.
- **Local HTTP server:** Uses the same origin logic for OPTIONS and JSON responses.

## Tests

- `nx test backend` (includes new `cors.spec.ts`)

Refs #4588
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b8ea8d8-1b25-4053-8cdb-f7ba319d1ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b8ea8d8-1b25-4053-8cdb-f7ba319d1ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

