### PR TITLE
fix(frontend): localize hardcoded inventory and form UI strings

### DIFF
--- a/.github/workflows/deploy-fullstack.yml
+++ b/.github/workflows/deploy-fullstack.yml
@@ -15,6 +15,8 @@ env:
   # Use the correct lowercase AWS region identifier.
   AWS_REGION: il-central-1
   NODE_VERSION: '20'
+  # Skip Nx Cloud when the linked org is unavailable (CI would otherwise exit immediately).
+  NX_NO_CLOUD: 'true'
   # Pre-release tags (semver prerelease, e.g. v1.2.3-beta.0) deploy to dev; stable release tags deploy to production.
   STAGE: ${{ contains(github.ref, '-') && 'dev' || 'production' }}
   # Optional: set repository secret NX_CLOUD_ACCESS_TOKEN after `nx connect` for remote cache.

--- a/.github/workflows/e2e-deployed-core-reusable.yml
+++ b/.github/workflows/e2e-deployed-core-reusable.yml
@@ -61,6 +61,7 @@ jobs:
           BACKEND_BASE_URL: ${{ inputs.backend_base_url }}
           E2E_AUTH_SECRET: ${{ secrets.E2E_AUTH_SECRET }}
           PLAYWRIGHT_HTML_OPEN: never
+          NX_NO_CLOUD: 'true'
         run: npx nx run frontend-e2e:e2e-deployed-core
 
       - name: Upload Playwright report

--- a/.github/workflows/e2e-localstack-core-regression.yml
+++ b/.github/workflows/e2e-localstack-core-regression.yml
@@ -10,6 +10,10 @@ concurrency:
   group: e2e-localstack-${{ github.ref }}
   cancel-in-progress: true
 
+# Nx Cloud org may be disabled; without this, `npx nx` exits before running tasks.
+env:
+  NX_NO_CLOUD: 'true'
+
 jobs:
   lint-and-unit-test:
     name: Lint & unit tests

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -195,6 +195,8 @@
       "addUser": "Add User",
       "showAllUsers": "Show All Users",
       "resetToWarehouse": "Reset to Warehouse",
+      "clearColumnSort": "Clear Column Sort",
+      "sortByProductClick": "Click to sort user columns by this product",
       "product": "Product",
       "upiProduct": "This product has unique identifiers (UPI)",
       "noInventory": "No Inventory Data",
@@ -291,7 +293,9 @@
     "submit-button": {
       "check-in": "Check In",
       "check-out": "Check Out"
-    }
+    },
+    "add-all-items-tooltip": "Add all items from this form",
+    "add-form-aria-label": "Add Form"
   },
   "reports": {
     "title": "Reports",

--- a/apps/frontend/src/assets/i18n/he.json
+++ b/apps/frontend/src/assets/i18n/he.json
@@ -194,6 +194,8 @@
       "addUser": "הוסף משתמש",
       "showAllUsers": "הצג את כל המשתמשים",
       "resetToWarehouse": "איפוס למחסן",
+      "clearColumnSort": "נקה מיון עמודות",
+      "sortByProductClick": "לחץ למיון עמודות המשתמשים לפי מוצר זה",
       "product": "מוצר",
       "upiProduct": "למוצר זה יש מזהים ייחודיים (צ׳)",
       "noInventory": "אין נתוני מלאי",
@@ -290,7 +292,9 @@
     "submit-button": {
       "check-in": "החזרה",
       "check-out": "לקיחה"
-    }
+    },
+    "add-all-items-tooltip": "הוסף את כל הפריטים מטופס זה",
+    "add-form-aria-label": "הוסף טופס"
   },
   "reports": {
     "title": "דוחות",

--- a/apps/frontend/src/ui/create-form/create-form.component.html
+++ b/apps/frontend/src/ui/create-form/create-form.component.html
@@ -62,8 +62,8 @@
                     class="add-form-header-btn"
                     [attr.data-testid]="'add-predefined-form-' + form.formID"
                     (click)="addAllItems(form.items); $event.stopPropagation();"
-                    matTooltip="Add all items from this form"
-                    aria-label="Add Form"
+                    [matTooltip]="'create-form.add-all-items-tooltip' | translate"
+                    [attr.aria-label]="'create-form.add-form-aria-label' | translate"
                     >
                     <mat-icon>add</mat-icon>
                   </button>

--- a/apps/frontend/src/ui/create-form/create-form.component.ts
+++ b/apps/frontend/src/ui/create-form/create-form.component.ts
@@ -26,6 +26,7 @@ import { FormsStore } from '../../store/forms.store';
 import { InventoryStore } from '../../store/inventory.store';
 import { UserDisplayComponent } from '../shared/user-display/user-display.component';
 import { MatRadioModule } from '@angular/material/radio';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
@@ -53,8 +54,9 @@ interface CreateFormConfig {
     InventoryListComponent,
     MatProgressSpinnerModule,
     UserDisplayComponent,
-    MatRadioModule
-],
+    MatRadioModule,
+    MatTooltipModule,
+  ],
   templateUrl: './create-form.component.html',
   styleUrls: ['./create-form.component.scss'],
 })

--- a/apps/frontend/src/ui/inventory/by-users/inventory-by-users.component.html
+++ b/apps/frontend/src/ui/inventory/by-users/inventory-by-users.component.html
@@ -84,7 +84,7 @@
             data-testid="inventory-by-users-clear-column-sort"
             (click)="clearProductColumnSort()"
           >
-            Clear Column Sort
+            {{ 'inventory.table.clearColumnSort' | translate }}
           </button>
         }
       </div>
@@ -131,7 +131,7 @@
               [class.upi-row]="shouldHighlightUpiRow(row)"
               [class.sorting-columns]="isProductSortingColumns(row.product.id)"
               (click)="onProductClick(row.product.id)"
-              [matTooltip]="'Click to sort user columns by this product'"
+              [matTooltip]="'inventory.table.sortByProductClick' | translate"
               [matTooltipPosition]="'above'">
             <div class="product-info">
               <span class="product-name">{{ row.product.name }}</span>

--- a/apps/frontend/src/ui/inventory/edit/item/editable-item.component.html
+++ b/apps/frontend/src/ui/inventory/edit/item/editable-item.component.html
@@ -64,7 +64,7 @@
   <button
     class="delete-button"
     mat-mini-fab
-    aria-label="Delete"
+    [attr.aria-label]="'common.delete' | translate"
     data-testid="editable-item-delete"
     (click)="remove.emit()"
   >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces remaining user-visible English literals in Angular templates with `ngx-translate` keys and adds matching entries in `en.json` and `he.json`.

## Follow-up fixes

- **Create form**: Import `MatTooltipModule` so the localized tooltip compiles (fixes E2E webServer build).
- **CI**: Set `NX_NO_CLOUD=true` in workflows that invoke `npx nx`, because the linked Nx Cloud org is disabled and Nx was exiting before running lint/tests/E2E.

## Changes

- **Inventory by users**: Localize product-column sort tooltip, "Clear Column Sort" button label (`inventory.table.*`).
- **Create form**: Localize predefined-form add button tooltip and aria-label (`create-form.add-all-items-tooltip`, `create-form.add-form-aria-label`).
- **Editable inventory item**: Use `common.delete` for the delete FAB aria-label.

## Verification

- `npm run validate:translations`
- `nx run frontend:lint`, `nx run frontend:test`
- `NX_NO_CLOUD=true npx nx run-many ...` (matches CI)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35bb9626-c38c-4d45-85c0-145bbc70be51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35bb9626-c38c-4d45-85c0-145bbc70be51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

