### PR TITLE
fix(ci): disable Nx Cloud for LocalStack full E2E workflow

### DIFF
--- a/.github/workflows/e2e-localstack-full-regression.yml
+++ b/.github/workflows/e2e-localstack-full-regression.yml
@@ -9,6 +9,10 @@ concurrency:
   group: e2e-localstack-full-${{ github.ref }}
   cancel-in-progress: true
 
+# Nx Cloud org may be disabled; without this, `npx nx` exits before running tasks.
+env:
+  NX_NO_CLOUD: 'true'
+
 jobs:
   e2e-full-regression:
     name: Full regression (LocalStack + Playwright)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The [E2E LocalStack Full Regression](https://github.com/NetanelAlbert/EquipTrack/actions/runs/23631949381) workflow failed because `npx nx` exited before Playwright ran:

> Nx Cloud: Workspace is unable to be authorized. Exiting run.
> This Nx Cloud organization has been disabled due to exceeding the FREE plan.

## Fix

Add workflow-level `NX_NO_CLOUD: 'true'` to `.github/workflows/e2e-localstack-full-regression.yml`, matching `e2e-localstack-core-regression.yml` and `deploy-fullstack.yml`. This runs Nx without requiring Nx Cloud when the linked org is unavailable.

## Testing

CI-only change; full E2E should run again once merged (or re-run the workflow on this branch).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-631ff311-cf70-49a9-8708-291f36e37ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-631ff311-cf70-49a9-8708-291f36e37ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

