### PR TITLE
Cursor Cloud Agent: Docker + LocalStack environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,48 @@
+# Cursor Cloud Agent image: Node + Docker (fuse-overlayfs) for LocalStack via compose.
+# See https://cursor.com/docs/cloud-agent/setup — paths are relative to `.cursor/` in environment.json.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl gnupg git openssh-server \
+    python3 make g++ \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker CE + compose plugin (pinned for Ubuntu 24.04 noble — Cursor “complex Docker” guidance)
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    docker-ce=5:28.5.2-1~ubuntu.24.04~noble \
+    docker-ce-cli=5:28.5.2-1~ubuntu.24.04~noble \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends fuse-overlayfs && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/docker && \
+    printf '%s\n' '{' \
+    '  "storage-driver": "fuse-overlayfs"' \
+    '}' > /etc/docker/daemon.json
+RUN apt-get update && apt-get install -y --no-install-recommends iptables && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# SSH + ubuntu user in docker group (Cursor cloud VM pattern)
+RUN echo 'PasswordAuthentication no\nChallengeResponseAuthentication no\nUsePAM no' > /etc/ssh/sshd_config.d/disable_password_auth.conf
+
+RUN id -u ubuntu &>/dev/null || useradd -m -s /bin/bash ubuntu
+RUN groupadd -f docker && usermod -aG docker ubuntu
+RUN usermod -aG sudo ubuntu
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+RUN echo "ubuntu:ubuntu" | chpasswd
+
+USER ubuntu
+WORKDIR /home/ubuntu

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://www.cursor.com/schemas/environment.schema.json",
+  "name": "EquipTrack (Docker + LocalStack)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "npm ci",
+  "start": "sudo service docker start && docker compose -f docker-compose.e2e.yml up -d --wait localstack",
+  "ports": [
+    {
+      "name": "LocalStack (AWS emulator)",
+      "port": 4566
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 Guidance for autonomous coding agents working in this repository.
 
+## Cursor Cloud specific instructions
+
+This repository defines a [Cloud Agent environment](https://cursor.com/docs/cloud-agent/setup) in `.cursor/environment.json`: the VM image includes Docker (fuse-overlayfs storage driver) and on each session start runs LocalStack from `docker-compose.e2e.yml` (port **4566**).
+
+- **AWS emulated endpoint**: `http://localhost:4566` (same as local E2E; see `docs/local-e2e.md`).
+- **Bring up / reprovision LocalStack** (idempotent): `npm run e2e:local:stack:up` or `docker compose -f docker-compose.e2e.yml up -d --wait localstack`.
+- **Seed DynamoDB, S3, Secrets Manager** after LocalStack is healthy: `npm run e2e:local:setup` (uses `AWS_ENDPOINT_URL` / test credentials like local E2E).
+- **Full local E2E stack** (LocalStack + seed + browsers + tests): see `docs/local-e2e.md` and scripts under `npm run e2e:local:*`.
+
+If Docker or LocalStack fails inside a nested container, follow Cursor’s [Running Docker](https://cursor.com/docs/cloud-agent/setup#running-docker) troubleshooting (storage driver / iptables).
+
 ## Github context
 - When asked about Github issue, pr, job etc., you can use gh cli to get more context
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repo-level [Cursor Cloud Agent](https://cursor.com/docs/cloud-agent/setup) configuration so cloud agents run with **Docker** (fuse-overlayfs + iptables-legacy per Cursor docs) and start **LocalStack** from the existing `docker-compose.e2e.yml` on port **4566**.

## Changes

- **`.cursor/Dockerfile`**: Ubuntu 24.04 base, Node.js 20, Docker CE + Compose plugin, fuse-overlayfs storage driver, ubuntu user in `docker` group.
- **`.cursor/environment.json`**: `npm ci` on boot; `start` runs `sudo service docker start` then `docker compose … up -d --wait localstack`; exposes port 4566.
- **`AGENTS.md`**: "Cursor Cloud specific instructions" section pointing to LocalStack commands and `docs/local-e2e.md`.

## Notes

- The `start` command is idempotent for an already-running LocalStack container (`docker compose up` is a no-op when healthy).
- Agents that need seeded tables/secrets should run `npm run e2e:local:setup` when relevant (documented in AGENTS.md).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d8c586f-9fbb-4c50-8692-480b026f992b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d8c586f-9fbb-4c50-8692-480b026f992b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

