### PR TITLE
feat(e2e): visual-review Playwright screenshots for agent UI review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ cloudfront-update-config.json
 scratchpads/
 .claude/worktrees
 .claude/settings.local.json
+
+# Playwright
+/test-results
+/playwright-report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,17 @@ This repository defines a [Cloud Agent environment](https://cursor.com/docs/clou
 
 If Docker or LocalStack fails inside a nested container, follow Cursor’s [Running Docker](https://cursor.com/docs/cloud-agent/setup#running-docker) troubleshooting (storage driver / iptables).
 
+### Visual review (screenshots for the agent to “see” the UI)
+
+Playwright runs headless, but it can **save full-page PNGs** you attach to a **vision-capable** chat so the model can comment on layout, copy, and obvious issues—without Google login (E2E auth is used).
+
+1. Ensure LocalStack + seed: `npm run e2e:local:prepare` (or rely on the cloud `start` + `e2e:local:setup`).
+2. Generate screenshots: `npm run e2e:local:visual`  
+   - Optional: `VISUAL_REVIEW_ROUTES="/my-items,/forms,/create-form" npm run e2e:local:visual` (comma-separated paths; default is `/my-items`).
+3. Open **`test-results/visual-review/*.png`** and **attach them** to the agent (or paste into the Cursor chat). Ask for a concise UI/design review.
+
+The spec lives at `apps/frontend-e2e/src/visual-review.spec.ts`.
+
 ## Github context
 - When asked about Github issue, pr, job etc., you can use gh cli to get more context
 

--- a/apps/frontend-e2e/project.json
+++ b/apps/frontend-e2e/project.json
@@ -26,6 +26,13 @@
       "options": {
         "command": "node scripts/ensure-local-e2e-before-playwright.js && E2E_AUTH_SECRET=e2e-local-secret BACKEND_BASE_URL=http://localhost:3000 npx playwright test -c apps/frontend-e2e/playwright.config.ts apps/frontend-e2e/src/screens/ apps/frontend-e2e/src/core-regression.spec.ts apps/frontend-e2e/src/core-regression-ui.spec.ts --project=chromium --workers=1"
       }
+    },
+    "e2e-local-visual": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "options": {
+        "command": "node scripts/ensure-local-e2e-before-playwright.js && E2E_AUTH_SECRET=e2e-local-secret BACKEND_BASE_URL=http://localhost:3000 npx playwright test -c apps/frontend-e2e/playwright.config.ts apps/frontend-e2e/src/visual-review.spec.ts --project=chromium --workers=1"
+      }
     }
   }
 }

--- a/apps/frontend-e2e/src/visual-review.spec.ts
+++ b/apps/frontend-e2e/src/visual-review.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { UserRole } from '@equip-track/shared';
+import { mintE2eJwt } from './helpers/e2e-auth';
+import {
+  bootstrapAuthenticatedSession,
+  ensureOrganizationIsSelected,
+} from './helpers/e2e-navigation';
+
+const backendBaseUrl =
+  process.env['BACKEND_BASE_URL'] || 'http://localhost:3000';
+const e2eSecret = process.env['E2E_AUTH_SECRET'] || 'e2e-local-secret';
+const organizationId = 'org-e2e-main';
+
+/** Comma-separated paths, e.g. `/my-items,/forms`. Leading slash optional. */
+function getRoutes(): string[] {
+  const raw = process.env['VISUAL_REVIEW_ROUTES'];
+  if (raw?.trim()) {
+    return raw
+      .split(',')
+      .map((r) => r.trim())
+      .filter(Boolean)
+      .map((r) => (r.startsWith('/') ? r : `/${r}`));
+  }
+  return ['/my-items'];
+}
+
+test.describe('visual review screenshots', () => {
+  test('capture full-page PNGs for agent / designer review', async ({
+    page,
+    request,
+  }) => {
+    const routes = getRoutes();
+
+    const jwt = await mintE2eJwt(request, {
+      backendBaseUrl,
+      e2eSecret,
+      userId: 'user-e2e-admin',
+      orgIdToRole: {
+        [organizationId]: UserRole.Admin,
+      },
+    });
+
+    await bootstrapAuthenticatedSession(page, jwt, organizationId);
+    await ensureOrganizationIsSelected(page, organizationId);
+
+    for (const path of routes) {
+      await page.goto(path, { waitUntil: 'load' });
+      const safeName =
+        path.replace(/^\/+/, '').replace(/\//g, '_') || 'root';
+      await page.screenshot({
+        path: `test-results/visual-review/${safeName}.png`,
+        fullPage: true,
+      });
+    }
+
+    expect(routes.length).toBeGreaterThan(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "backend:serve:e2e-local": "env STAGE=local AWS_REGION=us-east-1 AWS_ENDPOINT_URL=http://localhost:4566 AWS_ENDPOINT_URL_DYNAMODB=http://localhost:4566 AWS_ENDPOINT_URL_S3=http://localhost:4566 AWS_ENDPOINT_URL_SECRETSMANAGER=http://localhost:4566 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test E2E_AUTH_ENABLED=true E2E_AUTH_SECRET=e2e-local-secret BACKEND_PORT=3000 LOCAL_HTTP_SERVER=true bash -c \"nx run backend:build:development && node dist/apps/backend/main.js\"",
     "frontend:serve:e2e-local": "node scripts/write-runtime-config.js http://localhost:3000 && nx run frontend:serve",
     "e2e:local:test": "npm run e2e:local:prepare && npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never E2E_SKIP_LOCAL_E2E_ENSURE=true npx nx run frontend-e2e:e2e-local-core",
+    "e2e:local:visual": "npm run e2e:local:prepare && npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never E2E_SKIP_LOCAL_E2E_ENSURE=true npx nx run frontend-e2e:e2e-local-visual",
     "e2e:deployed:test": "npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never npx nx run frontend-e2e:e2e-deployed-core",
     "precommit": "nx affected -t lint,test --uncommitted --nxBail --exclude=frontend-e2e,backend-e2e && npm run validate:translations",
     "prepare": "husky"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small Playwright flow that saves **full-page PNGs** under `test-results/visual-review/` so a vision-capable agent (or designer) can review the UI without Google auth—using the existing **E2E login** path.

**Note:** #99 (Cloud Agent Docker + LocalStack) is already merged into `develop`. This PR is **only** the visual-review follow-up (one commit on top of current `develop`).

## Changes

- `apps/frontend-e2e/src/visual-review.spec.ts` — E2E admin session, optional `VISUAL_REVIEW_ROUTES` (comma-separated), full-page screenshots.
- `npm run e2e:local:visual` and `nx run frontend-e2e:e2e-local-visual`.
- `AGENTS.md` — “Visual review” subsection with steps.
- `.gitignore` — `/test-results`, `/playwright-report`.

## How to try

```bash
npm run e2e:local:visual
# optional:
VISUAL_REVIEW_ROUTES="/my-items,/forms" npm run e2e:local:visual
```

Then attach `test-results/visual-review/*.png` to a chat for review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d8c586f-9fbb-4c50-8692-480b026f992b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d8c586f-9fbb-4c50-8692-480b026f992b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

