### PR TITLE
chore: development environment setup with AGENTS.md improvements

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl gnupg git openssh-server \
+    ca-certificates curl gnupg git openssh-server sudo \
     python3 make g++ \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -41,7 +41,7 @@ RUN echo 'PasswordAuthentication no\nChallengeResponseAuthentication no\nUsePAM 
 RUN id -u ubuntu &>/dev/null || useradd -m -s /bin/bash ubuntu
 RUN groupadd -f docker && usermod -aG docker ubuntu
 RUN usermod -aG sudo ubuntu
-RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+RUN mkdir -p /etc/sudoers.d && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
 RUN echo "ubuntu:ubuntu" | chpasswd
 
 USER ubuntu

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,23 @@ This repository defines a [Cloud Agent environment](https://cursor.com/docs/clou
 
 If Docker or LocalStack fails inside a nested container, follow Cursor’s [Running Docker](https://cursor.com/docs/cloud-agent/setup#running-docker) troubleshooting (storage driver / iptables).
 
+### Running the full-stack locally
+
+- **Backend** (port 3000): `npm run backend:serve:e2e-local` — builds then starts the local HTTP server with E2E auth enabled and all AWS SDK env vars pointing at LocalStack.
+- **Frontend** (port 4200): `npm run frontend:serve:e2e-local` — writes runtime config and starts Angular dev server pointing at `localhost:3000`.
+- **Both together**: Start in separate terminals; the backend must be running before the frontend makes API calls.
+- **Lint**: `npx nx run-many --target=lint --all`
+- **Unit tests**: `npx nx run-many --target=test --all --exclude=frontend-e2e,backend-e2e`
+- **E2E tests**: `npm run e2e:local:test` (provisions LocalStack, installs Chromium, runs Playwright core regression).
+- **Pre-commit hook** runs `npm run precommit` (lint + test affected + validate translations).
+
+### Gotchas
+
+- The Docker socket may need `sudo chmod 666 /var/run/docker.sock` if the current user is not in the `docker` group.
+- Nx Cloud warnings about the FREE plan being exceeded are harmless — they just mean remote caching is disabled.
+- The `e2e-login` endpoint requires the secret via the `x-e2e-secret` **header** (not in the request body). Playwright E2E helpers handle this automatically; see `apps/frontend-e2e/src/helpers/e2e-auth.ts`.
+- The frontend defaults to Hebrew (RTL) localization. E2E tests force English via the `E2E_LANGUAGE_STORAGE_KEY` localStorage key.
+
 ## Github context
 - When asked about Github issue, pr, job etc., you can use gh cli to get more context
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ If Docker or LocalStack fails inside a nested container, follow Cursor’s [Runn
 - **Both together**: Start in separate terminals; the backend must be running before the frontend makes API calls.
 - **Lint**: `npx nx run-many --target=lint --all`
 - **Unit tests**: `npx nx run-many --target=test --all --exclude=frontend-e2e,backend-e2e`
-- **E2E tests**: `npm run e2e:local:test` (provisions LocalStack, installs Chromium, runs Playwright core regression).
+- **E2E tests**: `npm run e2e:local:test` (provisions LocalStack, installs Chromium, runs Playwright core regression). Chromium + system deps are pre-installed by the update script; to run the core regression alone: `E2E_SKIP_LOCAL_E2E_ENSURE=true PLAYWRIGHT_HTML_OPEN=never npx nx run frontend-e2e:e2e-local-core`.
 - **Pre-commit hook** runs `npm run precommit` (lint + test affected + validate translations).
 
 ### Gotchas

--- a/apps/backend/src/api/responses.ts
+++ b/apps/backend/src/api/responses.ts
@@ -10,7 +10,7 @@ export interface ErrorResponse {
 export const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers':
-    'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Accept,Origin,X-Requested-With,x-e2e-secret',
+    'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Accept,Origin,X-Requested-With',
   'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
   'Access-Control-Allow-Credentials': 'false',
   'Content-Type': 'application/json',

--- a/apps/backend/src/api/responses.ts
+++ b/apps/backend/src/api/responses.ts
@@ -10,7 +10,7 @@ export interface ErrorResponse {
 export const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers':
-    'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Accept,Origin,X-Requested-With',
+    'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Accept,Origin,X-Requested-With,x-e2e-secret',
   'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
   'Access-Control-Allow-Credentials': 'false',
   'Content-Type': 'application/json',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment, fixes a Docker build failure, and adds practical developer instructions to `AGENTS.md`.

### Changes

- **`.cursor/Dockerfile`**: Fixed Docker build failure — the base `ubuntu:24.04` image doesn't include `sudo` or `/etc/sudoers.d/`, causing `echo ... > /etc/sudoers.d/ubuntu` to fail with "Directory nonexistent". Added `sudo` to the initial `apt-get install` and `mkdir -p /etc/sudoers.d` as a safety net.
- **`AGENTS.md`**: Added "Running the full-stack locally" section with commands for backend, frontend, lint, unit tests, and E2E tests. Added "Gotchas" section documenting non-obvious issues (Docker socket permissions, Nx Cloud warnings, e2e-login header requirement, Hebrew/RTL default locale). Noted Chromium is pre-installed by the update script.
- Reverted an unintended CORS header modification.

### Environment Verification

| Check | Result |
|-------|--------|
| `npm ci` | All 1857 packages installed |
| LocalStack (Docker) | Healthy on port 4566 |
| LocalStack seed | DynamoDB tables, S3 bucket, JWT secrets created |
| `npx nx run-many --target=lint --all` | 5 projects passed (0 errors, 18 warnings) |
| `npx nx run-many --target=test --all` | 94 tests passed across 16 test suites |
| Backend (`npm run backend:serve:e2e-local`) | Running on port 3000 |
| Frontend (`npm run frontend:serve:e2e-local`) | Running on port 4200 |
| Playwright Chromium installed | Browser + system deps installed |
| E2E core regression tests | 4/4 passed (9.4s) |
| Full-stack UI walkthrough | Login, org selection, daily report, inventory pages all working |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-656add9f-4f93-4bbf-a19e-5bca0317dfd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-656add9f-4f93-4bbf-a19e-5bca0317dfd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

