### PR TITLE
fix(frontend): interpolate count in inventory success snackbars

### DIFF
--- a/apps/frontend/src/store/inventory.store.spec.ts
+++ b/apps/frontend/src/store/inventory.store.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { of, throwError } from 'rxjs';
+import type { InventoryItem } from '@equip-track/shared';
 import { InventoryStore } from './inventory.store';
 import { ApiService } from '../services/api.service';
 import { NotificationService } from '../services/notification.service';
@@ -10,6 +11,14 @@ import { OrganizationStore } from './organization.store';
 describe('InventoryStore', () => {
   let store: InstanceType<typeof InventoryStore>;
   let executeSpy: jest.Mock;
+  let addInventoryExecute: jest.Mock;
+  let removeInventoryExecute: jest.Mock;
+  let getInventoryExecute: jest.Mock;
+  let notificationService: {
+    showSuccess: jest.Mock;
+    showError: jest.Mock;
+    handleApiError: jest.Mock;
+  };
 
   beforeEach(() => {
     executeSpy = jest.fn().mockReturnValue(
@@ -19,6 +28,17 @@ describe('InventoryStore', () => {
         products: [],
       })
     );
+    addInventoryExecute = jest.fn().mockReturnValue(of({ status: true }));
+    removeInventoryExecute = jest.fn().mockReturnValue(of({ status: true }));
+    getInventoryExecute = jest.fn().mockReturnValue(
+      of({ status: true, totalItems: [] })
+    );
+
+    notificationService = {
+      showError: jest.fn(),
+      handleApiError: jest.fn(),
+      showSuccess: jest.fn(),
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -27,19 +47,15 @@ describe('InventoryStore', () => {
           useValue: {
             endpoints: {
               getUserInventory: { execute: executeSpy },
-              getInventory: { execute: jest.fn() },
-              addInventory: { execute: jest.fn() },
-              removeInventory: { execute: jest.fn() },
+              getInventory: { execute: getInventoryExecute },
+              addInventory: { execute: addInventoryExecute },
+              removeInventory: { execute: removeInventoryExecute },
             },
           },
         },
         {
           provide: NotificationService,
-          useValue: {
-            showError: jest.fn(),
-            handleApiError: jest.fn(),
-            showSuccess: jest.fn(),
-          },
+          useValue: notificationService,
         },
         {
           provide: UserStore,
@@ -79,6 +95,33 @@ describe('InventoryStore', () => {
     await store.ensureUserInventoryLoaded('user-once');
 
     expect(executeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('addInventory passes item count to success notification for i18n interpolation', async () => {
+    const items: InventoryItem[] = [
+      { productId: 'a', quantity: 1 },
+      { productId: 'b', quantity: 2 },
+    ];
+
+    await store.addInventory(items);
+
+    expect(notificationService.showSuccess).toHaveBeenCalledWith(
+      'inventory.add.success',
+      'Inventory items added successfully',
+      { count: 2 }
+    );
+  });
+
+  it('removeInventory passes item count to success notification for i18n interpolation', async () => {
+    const items: InventoryItem[] = [{ productId: 'a', quantity: 1 }];
+
+    await store.removeInventory(items);
+
+    expect(notificationService.showSuccess).toHaveBeenCalledWith(
+      'inventory.remove.success',
+      'Inventory items removed successfully',
+      { count: 1 }
+    );
   });
 
   it('ensureUserInventoryLoaded retries after a failed fetch', async () => {

--- a/apps/frontend/src/store/inventory.store.ts
+++ b/apps/frontend/src/store/inventory.store.ts
@@ -323,7 +323,8 @@ export const InventoryStore = signalStore(
           });
           notificationService.showSuccess(
             'inventory.add.success',
-            'Inventory items added successfully'
+            'Inventory items added successfully',
+            { count: items.length }
           );
 
           // Refresh inventory after successful add
@@ -384,7 +385,8 @@ export const InventoryStore = signalStore(
           });
           notificationService.showSuccess(
             'inventory.remove.success',
-            'Inventory items removed successfully'
+            'Inventory items removed successfully',
+            { count: items.length }
           );
 
           // Refresh inventory after successful remove


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Success messages for adding and removing inventory used translation keys with `{{count}}` placeholders, but `NotificationService.showSuccess` was called without interpolation params. Users saw the literal `{{count}}` in Hebrew and English.

## Changes
- Pass `{ count: items.length }` when showing `inventory.add.success` and `inventory.remove.success` from `InventoryStore`.
- Add unit tests asserting the notification receives the correct count.

## Notes
Other `{{...}}` success strings (e.g. user invite with `{{email}}`) already receive params at the call site. Inventory add/remove were the only snackbar success keys with missing interpolation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a9f249c-8d81-490b-9aeb-c129158f9690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a9f249c-8d81-490b-9aeb-c129158f9690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

