### PR TITLE
fix(inventory): UPI duplicate false positive after deleting a row

### DIFF
--- a/apps/frontend/src/ui/inventory/edit/item/editable-item.component.html
+++ b/apps/frontend/src/ui/inventory/edit/item/editable-item.component.html
@@ -102,7 +102,7 @@
           mat-icon-button
           matSuffix
           [attr.data-testid]="'editable-item-upi-delete-' + upiIndex"
-          (click)="upisControl().removeAt(upiIndex)"
+          (click)="removeUpiAt(upiIndex)"
         >
           <mat-icon>delete</mat-icon>
         </button>

--- a/apps/frontend/src/ui/inventory/edit/item/editable-item.component.spec.ts
+++ b/apps/frontend/src/ui/inventory/edit/item/editable-item.component.spec.ts
@@ -81,4 +81,30 @@ describe('EditableItemComponent', () => {
 
     expect(component.upisControl().length).toBe(len);
   });
+
+  // Regression: issue #106 — deleting first UPI must not leave stale duplicate validators
+  it('should stay valid after deleting the first UPI when values were unique', () => {
+    component.productIdControl().setValue('upi-prod');
+    fixture.detectChanges();
+
+    component.quantityControl().setValue(2);
+    fixture.detectChanges();
+
+    const upis = component.upisControl();
+    upis.at(0)?.setValue('1');
+    upis.at(1)?.setValue('2');
+    fixture.detectChanges();
+
+    expect(upis.at(0)?.errors).toBeNull();
+    expect(upis.at(1)?.errors).toBeNull();
+
+    component.removeUpiAt(0);
+    fixture.detectChanges();
+
+    expect(component.quantityControl().value).toBe(1);
+    expect(upis.length).toBe(1);
+    expect(upis.at(0)?.value).toBe('2');
+    expect(upis.at(0)?.errors).toBeNull();
+    expect(component.control().valid).toBe(true);
+  });
 });

--- a/apps/frontend/src/ui/inventory/edit/item/editable-item.component.ts
+++ b/apps/frontend/src/ui/inventory/edit/item/editable-item.component.ts
@@ -230,6 +230,7 @@ export class EditableItemComponent implements OnInit {
           ) {
             upisControl.removeAt(upisControl.length - 1, { emitEvent: false });
           }
+          this.updateUpisValidations(0);
           quantityControl.setValue(
             EditableItemComponent.MAX_UPI_QUANTITY,
             { emitEvent: false }
@@ -264,7 +265,7 @@ export class EditableItemComponent implements OnInit {
     );
     if (index !== -1) {
       this.upisControl().removeAt(index, { emitEvent: false });
-      //
+      this.updateUpisValidations(0);
       return true;
     }
     return false;
@@ -272,7 +273,7 @@ export class EditableItemComponent implements OnInit {
 
   private updateUpisValidations(fromIndex: number) {
     for (let i = fromIndex; i < this.upisControl().length; i++) {
-      this.setUPIValidations(this.upisControl().at(i), i);
+      this.setUPIValidations(this.upisControl().at(i));
     }
   }
 
@@ -295,42 +296,66 @@ export class EditableItemComponent implements OnInit {
       });
   }
 
-  private watchDuplicate(firstIndex: number, duplicateIndex: number) {
-    const firstControl = this.upisControl().at(firstIndex);
-    const duplicateControl = this.upisControl().at(duplicateIndex);
+  private watchDuplicate(
+    upisArray: FormArray<FormControl<string | null>>,
+    firstIndex: number,
+    duplicateIndex: number
+  ) {
+    const firstControl = upisArray.at(firstIndex);
+    const duplicateControl = upisArray.at(duplicateIndex);
 
     firstControl.valueChanges.pipe(first()).subscribe(() => {
       duplicateControl?.updateValueAndValidity();
     });
   }
 
-  private createUpiDuplicateValidator(index: number): ValidatorFn {
+  /**
+   * Resolves the control's index at validation time so duplicate checks stay
+   * correct after UPI rows are removed (stale closure indices caused false positives).
+   */
+  private createUpiDuplicateValidator(): ValidatorFn {
     return (control: AbstractControl) => {
       const value = control.value;
       if (!value) return null;
-      const otherMatchIndex = this.upisControl().controls.findIndex(
+      const parent = control.parent;
+      if (!(parent instanceof FormArray)) {
+        return null;
+      }
+      const upisArray = parent as FormArray<FormControl<string | null>>;
+      const index = upisArray.controls.indexOf(control);
+      if (index === -1) {
+        return null;
+      }
+      const otherMatchIndex = upisArray.controls.findIndex(
         (upi, i) => i !== index && upi.value === value
       );
       if (otherMatchIndex !== -1) {
-        this.watchDuplicate(otherMatchIndex, index);
+        this.watchDuplicate(upisArray, otherMatchIndex, index);
         return { duplicate: true };
       }
       return null;
     };
   }
 
-  private setUPIValidations(
-    control: FormControl<string | null>,
-    index: number
-  ) {
+  private setUPIValidations(control: FormControl<string | null>) {
     control.clearValidators();
     if (this.isUPI()) {
       control.addValidators([
         Validators.required,
-        this.createUpiDuplicateValidator(index),
+        this.createUpiDuplicateValidator(),
       ]);
     }
     control.updateValueAndValidity();
+  }
+
+  /** Removes a UPI row and reapplies duplicate validators with correct indices. */
+  removeUpiAt(upiIndex: number): void {
+    const upis = this.upisControl();
+    if (upiIndex < 0 || upiIndex >= upis.length) {
+      return;
+    }
+    upis.removeAt(upiIndex);
+    this.updateUpisValidations(0);
   }
 
   protected addUpi(emitEvent = true) {
@@ -341,10 +366,9 @@ export class EditableItemComponent implements OnInit {
       return -1;
     }
     const control = new FormControl('');
-    const newIndex = this.upisControl().length;
-    this.setUPIValidations(control, newIndex);
     this.upisControl().push(control, { emitEvent });
-    return newIndex;
+    this.setUPIValidations(control);
+    return this.upisControl().length - 1;
   }
 
   private initInputProduct() {

--- a/apps/frontend/src/ui/inventory/edit/item/editable-item.component.ts
+++ b/apps/frontend/src/ui/inventory/edit/item/editable-item.component.ts
@@ -322,7 +322,7 @@ export class EditableItemComponent implements OnInit {
         return null;
       }
       const upisArray = parent as FormArray<FormControl<string | null>>;
-      const index = upisArray.controls.indexOf(control);
+      const index = upisArray.controls.findIndex((c) => c === control);
       if (index === -1) {
         return null;
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes false **UPI must be unique** validation after removing a UPI row from a serial-tracked line item (e.g. delete the first UPI when values were `1` and `2`).

## Root cause
The duplicate validator closed over the UPI control’s **index at creation time**. After `removeAt`, indices shifted but validators were not refreshed, so the remaining control could be compared with a **stale** index and incorrectly match itself.

## Changes
- Resolve the control’s index from `control.parent` at validation time.
- Re-run `updateUpisValidations` after UPI removals (`removeUpiAt`, `removeEmptyUpi`, cap trim).
- Push new UPI controls to the `FormArray` **before** `setUPIValidations` so the parent exists when validators run.

## Tests
- Added unit regression in `editable-item.component.spec.ts` mirroring issue STR.

Closes #106
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23bd7421-7768-457f-8bcb-486b0ab75462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23bd7421-7768-457f-8bcb-486b0ab75462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

