### PR TITLE
fix(frontend): fix create-form page crash and add e2e tests

### DIFF
--- a/apps/frontend-e2e/project.json
+++ b/apps/frontend-e2e/project.json
@@ -10,7 +10,7 @@
       "executor": "nx:run-commands",
       "cache": false,
       "options": {
-        "command": "node scripts/ensure-local-e2e-before-playwright.js && E2E_AUTH_SECRET=e2e-local-secret BACKEND_BASE_URL=http://localhost:3000 npx playwright test -c apps/frontend-e2e/playwright.config.ts apps/frontend-e2e/src/core-regression.spec.ts apps/frontend-e2e/src/core-regression-ui.spec.ts --project=chromium --workers=1"
+        "command": "node scripts/ensure-local-e2e-before-playwright.js && E2E_AUTH_SECRET=e2e-local-secret BACKEND_BASE_URL=http://localhost:3000 npx playwright test -c apps/frontend-e2e/playwright.config.ts apps/frontend-e2e/src/core-regression.spec.ts apps/frontend-e2e/src/core-regression-ui.spec.ts apps/frontend-e2e/src/create-form.spec.ts --project=chromium --workers=1"
       }
     },
     "e2e-deployed-core": {
@@ -24,7 +24,7 @@
       "executor": "nx:run-commands",
       "cache": false,
       "options": {
-        "command": "node scripts/ensure-local-e2e-before-playwright.js && E2E_AUTH_SECRET=e2e-local-secret BACKEND_BASE_URL=http://localhost:3000 npx playwright test -c apps/frontend-e2e/playwright.config.ts apps/frontend-e2e/src/screens/ apps/frontend-e2e/src/core-regression.spec.ts apps/frontend-e2e/src/core-regression-ui.spec.ts --project=chromium --workers=1"
+        "command": "node scripts/ensure-local-e2e-before-playwright.js && E2E_AUTH_SECRET=e2e-local-secret BACKEND_BASE_URL=http://localhost:3000 npx playwright test -c apps/frontend-e2e/playwright.config.ts apps/frontend-e2e/src/screens/ apps/frontend-e2e/src/core-regression.spec.ts apps/frontend-e2e/src/core-regression-ui.spec.ts apps/frontend-e2e/src/create-form.spec.ts --project=chromium --workers=1"
       }
     }
   }

--- a/apps/frontend-e2e/src/create-form.spec.ts
+++ b/apps/frontend-e2e/src/create-form.spec.ts
@@ -1,0 +1,285 @@
+import { Page, expect, test } from '@playwright/test';
+import { UserRole } from '@equip-track/shared';
+import { mintE2eJwt } from './helpers/e2e-auth';
+import {
+  E2E_LANGUAGE_STORAGE_KEY,
+  E2E_TEST_APP_LANGUAGE,
+} from './helpers/e2e-locale';
+
+const backendBaseUrl =
+  process.env['BACKEND_BASE_URL'] || 'http://localhost:3000';
+const e2eSecret = process.env['E2E_AUTH_SECRET'] || 'e2e-local-secret';
+const organizationId = 'org-e2e-main';
+
+async function bootstrapAuthenticatedSession(
+  page: Page,
+  token: string
+): Promise<void> {
+  await page.addInitScript(
+    ({
+      jwt,
+      selectedOrganizationId,
+      languageKey,
+      languageValue,
+    }: {
+      jwt: string;
+      selectedOrganizationId: string;
+      languageKey: string;
+      languageValue: string;
+    }) => {
+      window.localStorage.setItem('equip-track-token', jwt);
+      window.localStorage.setItem(
+        'equip-track-selected-org',
+        selectedOrganizationId
+      );
+      window.localStorage.setItem(languageKey, languageValue);
+    },
+    {
+      jwt: token,
+      selectedOrganizationId: organizationId,
+      languageKey: E2E_LANGUAGE_STORAGE_KEY,
+      languageValue: E2E_TEST_APP_LANGUAGE,
+    }
+  );
+}
+
+async function ensureOrganizationIsSelected(page: Page): Promise<void> {
+  await page.goto('/');
+
+  try {
+    await expect(page).toHaveURL(/\/my-items/, { timeout: 20000 });
+    return;
+  } catch {
+    // Staying on / — show org grid and require a click.
+  }
+
+  const orgSelect = page.getByTestId(
+    `select-organization-${organizationId}`
+  );
+  // On cold starts the app may still be loading (no org buttons yet).
+  // Wait longer and retry goto once.
+  try {
+    await expect(orgSelect).toBeVisible({ timeout: 20000 });
+  } catch {
+    await page.goto('/');
+    try {
+      await expect(page).toHaveURL(/\/my-items/, { timeout: 20000 });
+      return;
+    } catch {
+      // Retry org select
+    }
+    await expect(orgSelect).toBeVisible({ timeout: 20000 });
+  }
+  await orgSelect.click({ timeout: 30000 });
+  await expect(page).toHaveURL(/\/my-items/, { timeout: 20000 });
+}
+
+function clickSideNavRoute(page: Page, route: string): Promise<void> {
+  return (async () => {
+    const link = page.getByTestId(`nav-link-${route}`);
+    await link.waitFor({ state: 'attached', timeout: 20000 });
+    await link.evaluate((el: HTMLElement) => el.click());
+
+    const leaveUnsaved = page.getByRole('button', { name: /^Leave$/i });
+    try {
+      await leaveUnsaved.waitFor({ state: 'visible', timeout: 4000 });
+      await leaveUnsaved.click();
+    } catch {
+      // No unsaved-changes dialog
+    }
+  })();
+}
+
+async function openCreateFormPage(page: Page): Promise<void> {
+  const createFormPage = page.getByTestId('create-form-page');
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const orgPicker = page.getByTestId('organization-selection-page');
+    const onOrgPicker =
+      (await orgPicker.count()) > 0 &&
+      (await orgPicker.first().isVisible().catch(() => false));
+
+    if (onOrgPicker) {
+      const selectBtn = page.getByTestId(
+        `select-organization-${organizationId}`
+      );
+      await expect(selectBtn).toBeEnabled({ timeout: 20000 });
+      await selectBtn.click();
+      await expect(page).toHaveURL(/\/my-items/, { timeout: 20000 });
+    }
+
+    await clickSideNavRoute(page, 'create-form');
+
+    try {
+      await createFormPage.waitFor({ state: 'visible', timeout: 10000 });
+      return;
+    } catch {
+      // Retry
+    }
+
+    if (
+      await page
+        .getByTestId('login-page')
+        .isVisible()
+        .catch(() => false)
+    ) {
+      throw new Error(
+        'Unexpected redirect to login while opening create-form page'
+      );
+    }
+  }
+
+  await expect(createFormPage).toBeVisible({ timeout: 15000 });
+}
+
+async function navigateToCreateForm(
+  page: Page,
+  token: string
+): Promise<void> {
+  await bootstrapAuthenticatedSession(page, token);
+  await ensureOrganizationIsSelected(page);
+  await openCreateFormPage(page);
+}
+
+test.describe('create-form page', () => {
+  let adminToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    adminToken = await mintE2eJwt(request, {
+      backendBaseUrl,
+      e2eSecret,
+      userId: 'user-e2e-admin',
+      orgIdToRole: {
+        [organizationId]: UserRole.Admin,
+      },
+    });
+  });
+
+  test('renders without page-level errors', async ({ page }) => {
+    test.setTimeout(90_000);
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await navigateToCreateForm(page, adminToken);
+
+    await expect(page.getByTestId('create-form-user-select')).toBeVisible({
+      timeout: 10000,
+    });
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('user select dropdown opens and shows options', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await navigateToCreateForm(page, adminToken);
+
+    const userSelect = page.getByTestId('create-form-user-select');
+    await expect(userSelect).toBeVisible();
+
+    await userSelect.locator('.ng-select-container').click();
+
+    const filterInput = userSelect.locator('.ng-input input');
+    await expect(filterInput).toBeVisible({ timeout: 10000 });
+
+    const options = page.locator('.ng-dropdown-panel .ng-option');
+    await expect(options.first()).toBeVisible({ timeout: 10000 });
+    const count = await options.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('user can be selected and displays correctly', async ({ page }) => {
+    test.setTimeout(90_000);
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await navigateToCreateForm(page, adminToken);
+
+    const userSelect = page.getByTestId('create-form-user-select');
+    await userSelect.locator('.ng-select-container').click();
+
+    const filterInput = userSelect.locator('.ng-input input');
+    await expect(filterInput).toBeVisible({ timeout: 10000 });
+    await filterInput.fill('E2E Customer');
+
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    const selectedValue = userSelect.locator('.ng-value');
+    await expect(selectedValue).toBeVisible({ timeout: 5000 });
+
+    const userDisplay = selectedValue.locator('app-user-display');
+    await expect(userDisplay).toBeVisible();
+    await expect(userDisplay.locator('.user-name')).toContainText('E2E');
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('form type radio buttons switch between check-out and check-in', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    await navigateToCreateForm(page, adminToken);
+
+    const checkoutRadio = page.getByTestId('form-type-checkout');
+    const checkinRadio = page.getByTestId('form-type-checkin');
+
+    await expect(checkoutRadio).toBeVisible();
+    await expect(checkinRadio).toBeVisible();
+
+    const explanation = page.locator('.explanation p');
+    await expect(explanation).toContainText('Check out');
+
+    await checkinRadio.click();
+    await expect(explanation).toContainText('Check in');
+
+    await checkoutRadio.click();
+    await expect(explanation).toContainText('Check out');
+  });
+
+  test('description input accepts text', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await navigateToCreateForm(page, adminToken);
+
+    const descriptionInput = page.getByTestId('create-form-description-input');
+    await expect(descriptionInput).toBeVisible();
+    await descriptionInput.fill('Test form description');
+    await expect(descriptionInput).toHaveValue('Test form description');
+  });
+
+  test('user select search filters options correctly', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await navigateToCreateForm(page, adminToken);
+
+    const userSelect = page.getByTestId('create-form-user-select');
+    await userSelect.locator('.ng-select-container').click();
+
+    const filterInput = userSelect.locator('.ng-input input');
+    await expect(filterInput).toBeVisible({ timeout: 10000 });
+
+    const options = page.locator('.ng-dropdown-panel .ng-option');
+    await expect(options.first()).toBeVisible({ timeout: 10000 });
+    const allCount = await options.count();
+
+    await filterInput.fill('nonexistent-user-xyz');
+
+    const noResultsOption = page.locator(
+      '.ng-dropdown-panel .ng-option.ng-option-disabled'
+    );
+    await expect(noResultsOption).toBeVisible({ timeout: 5000 });
+
+    await filterInput.clear();
+    await filterInput.fill('E2E Customer');
+
+    const customerOptions = page.locator(
+      '.ng-dropdown-panel .ng-option:not(.ng-option-disabled)'
+    );
+    await expect(customerOptions.first()).toBeVisible({ timeout: 5000 });
+    const customerCount = await customerOptions.count();
+    expect(customerCount).toBeGreaterThan(0);
+    expect(customerCount).toBeLessThanOrEqual(allCount);
+  });
+});

--- a/apps/frontend/src/ui/create-form/create-form.component.html
+++ b/apps/frontend/src/ui/create-form/create-form.component.html
@@ -47,12 +47,14 @@
           <app-user-display [user]="item" />
         </ng-template>
         <ng-template ng-option-tmp let-item="item">
-          <div
-            [attr.data-testid]="'create-form-user-option-' + item.user.id"
-            class="create-form-user-option-row"
-          >
-            <app-user-display [user]="item" />
-          </div>
+          @if (item?.user) {
+            <div
+              [attr.data-testid]="'create-form-user-option-' + item.user.id"
+              class="create-form-user-option-row"
+            >
+              <app-user-display [user]="item" />
+            </div>
+          }
         </ng-template>
       </ng-select>
     </div>

--- a/apps/frontend/src/ui/create-form/create-form.component.ts
+++ b/apps/frontend/src/ui/create-form/create-form.component.ts
@@ -77,7 +77,7 @@ export class CreateFormComponent implements OnInit, CanComponentDeactivate {
   private inventoryStore = inject(InventoryStore);
   private route = inject(ActivatedRoute);
   form = this.fb.group({
-    userID: ['', Validators.required],
+    userID: [null as string | null, Validators.required],
     formDescription: ['', Validators.required],
     formType: [FormType.CheckOut, Validators.required],
   });

--- a/apps/frontend/src/ui/shared/user-display/user-display.component.html
+++ b/apps/frontend/src/ui/shared/user-display/user-display.component.html
@@ -1,16 +1,18 @@
-<div class="user-display">
-  <span class="user-name">{{ user().user.name }}</span>
-  @if (departmentInfo(); as info) {
-    <span class="department-info">
-      @if (info.mainDepartment) {
-        <span class="main-department">{{ info.mainDepartment }}</span>
-      }
-      @if (info.subDepartment) {
-        <span class="sub-department">/ {{ info.subDepartment }}</span>
-      }
-      @if (info.roleDescription) {
-        <span class="role-description">({{ info.roleDescription }})</span>
-      }
-    </span>
-  }
-</div>
+@if (user()?.user; as u) {
+  <div class="user-display">
+    <span class="user-name">{{ u.name }}</span>
+    @if (departmentInfo(); as info) {
+      <span class="department-info">
+        @if (info.mainDepartment) {
+          <span class="main-department">{{ info.mainDepartment }}</span>
+        }
+        @if (info.subDepartment) {
+          <span class="sub-department">/ {{ info.subDepartment }}</span>
+        }
+        @if (info.roleDescription) {
+          <span class="role-description">({{ info.roleDescription }})</span>
+        }
+      </span>
+    }
+  </div>
+}

--- a/apps/frontend/src/ui/shared/user-display/user-display.component.ts
+++ b/apps/frontend/src/ui/shared/user-display/user-display.component.ts
@@ -24,7 +24,7 @@ export class UserDisplayComponent {
 
   departmentInfo = computed(() => {
     const userData = this.user();
-    const department = userData.userInOrganization.department;
+    const department = userData?.userInOrganization?.department;
 
     if (!department) {
       return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #82 introduced `@ng-select/ng-select` to replace `mat-select` for the user picker on the create-form page. This caused the page to crash with `TypeError: Cannot read properties of undefined (reading 'name')` in `UserDisplayComponent`.

### Root Cause

When ng-select has `bindValue="user.id"` and `bindLabel="user.name"`, and the reactive form initializes `userID` to `''` (empty string), ng-select creates a synthetic item with flat dotted keys like `{ "user.name": null, "user.id": "" }`. This flat object gets passed to `UserDisplayComponent` via `ng-label-tmp`, which expects a nested `UserAndUserInOrganization` object with `item.user.name`, causing the crash.

### Fix

- **Changed form `userID` initial value** from `''` to `null` in `create-form.component.ts`, so ng-select doesn't create a phantom selected item on load.
- **Added defensive null checks** in `UserDisplayComponent` template (`user()?.user` guard) and computed signal (`userData?.userInOrganization?.department`).
- **Added `@if` guard** on `ng-option-tmp` in `create-form.component.html` to skip rendering when the item lacks a proper `user` property.

### E2E Tests Added

New `create-form.spec.ts` with 6 Playwright tests covering:
- Page renders without page-level errors (would have caught the original bug)
- User select dropdown opens and shows options
- User can be selected and `UserDisplayComponent` renders correctly
- Form type radio buttons toggle between check-out/check-in explanations
- Description input accepts text
- User search filtering works (gibberish returns no results, real name filters correctly)

All tests are included in the `e2e-local-core` and `e2e-local-full` targets.

### Evidence

[Create-form page working with console showing no errors](https://cursor.com/agents/bc-d339233e-a2dd-4470-ae6e-74ee833a844b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_form_page_working.webp)

E2E test results (10 passed, 0 failed):
[e2e_test_results.log](https://cursor.com/agents/bc-d339233e-a2dd-4470-ae6e-74ee833a844b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_test_results.log)

Fixes the regression from #82.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d339233e-a2dd-4470-ae6e-74ee833a844b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d339233e-a2dd-4470-ae6e-74ee833a844b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

