### PR TITLE
fix: remove deprecated allowSignalWrites flag from effect()

### DIFF
--- a/apps/frontend/src/ui/inventory/search/inventory-search.component.ts
+++ b/apps/frontend/src/ui/inventory/search/inventory-search.component.ts
@@ -386,14 +386,11 @@ export class InventorySearchComponent {
 
   constructor() {
     // Effect to emit filtered items when they change
-    effect(
-      () => {
-        const filtered = this.filteredAndSortedItems();
-        this.resultCount.set(filtered.length);
-        this.filteredItems.emit(filtered);
-      },
-      { allowSignalWrites: true }
-    );
+    effect(() => {
+      const filtered = this.filteredAndSortedItems();
+      this.resultCount.set(filtered.length);
+      this.filteredItems.emit(filtered);
+    });
 
     // Effect to emit filter changes
     effect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove the deprecated `allowSignalWrites: true` option from the `effect()` call in `inventory-search.component.ts`.

Angular has deprecated this flag — writes inside `effect()` are always allowed now and the option no longer has any impact. Removing it eliminates the console warning:

> The 'allowSignalWrites' flag is deprecated and no longer impacts effect() (writes are always allowed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34ca0475-e157-479e-b3f7-0fcf4482261c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34ca0475-e157-479e-b3f7-0fcf4482261c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

