### PR TITLE
feat: Docker Compose full-stack preview with LocalStack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.git
+.github
+.nx
+coverage
+**/.angular/cache
+tmp
+*.log
+.env
+.env.*
+!.env.example

--- a/apps/backend/src/local-http-server.ts
+++ b/apps/backend/src/local-http-server.ts
@@ -196,6 +196,7 @@ async function invokeLambdaHandler(
 
 export async function startLocalHttpServer(): Promise<void> {
   const port = Number(process.env.BACKEND_PORT || 3000);
+  const listenHost = process.env.BACKEND_LISTEN_HOST?.trim() || undefined;
 
   const server = createServer(async (req, res) => {
     const method = (req.method || 'GET').toUpperCase();
@@ -243,10 +244,17 @@ export async function startLocalHttpServer(): Promise<void> {
     }
   });
 
-  await new Promise<void>((resolve) => {
-    server.listen(port, () => {
-      console.log(`[local-http-server] listening on http://localhost:${port}`);
+  await new Promise<void>((resolve, reject) => {
+    const onListen = () => {
+      const where = listenHost ? `${listenHost}:${port}` : `localhost:${port}`;
+      console.log(`[local-http-server] listening on http://${where}`);
       resolve();
-    });
+    };
+    if (listenHost) {
+      server.listen(port, listenHost, onListen);
+    } else {
+      server.listen(port, onListen);
+    }
+    server.on('error', reject);
   });
 }

--- a/apps/frontend/src/services/runtime-config.service.ts
+++ b/apps/frontend/src/services/runtime-config.service.ts
@@ -3,10 +3,20 @@ import { environment } from '../environments/environment';
 
 interface RuntimeConfig {
   apiUrl?: string;
+  /** When true, API calls use the SPA origin (e.g. nginx proxies /api → backend). */
+  useSameOriginForApi?: boolean;
 }
 
 function isRuntimeConfig(value: unknown): value is RuntimeConfig {
-  return typeof value === 'object' && value !== null;
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const o = value as Record<string, unknown>;
+  const sameOrigin = o['useSameOriginForApi'];
+  if (sameOrigin !== undefined && typeof sameOrigin !== 'boolean') {
+    return false;
+  }
+  return true;
 }
 
 /** True when apiUrl targets loopback or RFC1918 — unsafe from a public HTTPS origin (Chrome PNA, mixed behavior). */
@@ -52,7 +62,12 @@ export class RuntimeConfigService {
     apiUrl: environment.apiUrl,
   };
 
+  private sameOriginApi = false;
+
   get apiUrl(): string {
+    if (this.sameOriginApi) {
+      return '';
+    }
     return this.config.apiUrl || environment.apiUrl;
   }
 
@@ -82,6 +97,13 @@ export class RuntimeConfigService {
             apiUrl: fileApiUrl,
           };
         }
+      }
+      if (configFromFile['useSameOriginForApi'] === true) {
+        this.sameOriginApi = true;
+        this.config = {
+          ...this.config,
+          apiUrl: '',
+        };
       }
     } catch {
       // No-op fallback to environment config when runtime file is unavailable.

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -1,0 +1,70 @@
+# Local full-stack preview: LocalStack (DynamoDB, S3, Secrets Manager) + backend + nginx (Angular SPA).
+# Usage:
+#   npm run docker:preview:up
+# Open http://localhost:4280 — API is proxied at /api (same-origin; see runtime-config.json).
+#
+# Default E2E login secret: e2e-docker-preview-secret (override E2E_AUTH_SECRET in compose if needed).
+
+services:
+  localstack:
+    image: public.ecr.aws/localstack/localstack:3.8
+    container_name: equiptrack-preview-localstack
+    ports:
+      - '4566:4566'
+    environment:
+      - SERVICES=dynamodb,s3,secretsmanager
+      - AWS_DEFAULT_REGION=us-east-1
+      - DEBUG=0
+      - PERSISTENCE=1
+    volumes:
+      - equiptrack-preview-localstack:/var/lib/localstack
+    healthcheck:
+      test: ['CMD', 'bash', '-c', 'curl -fsS http://localhost:4566/_localstack/health > /dev/null']
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  backend:
+    build:
+      context: .
+      dockerfile: docker/preview/Dockerfile
+      target: preview-backend
+    container_name: equiptrack-preview-backend
+    depends_on:
+      localstack:
+        condition: service_healthy
+    environment:
+      STAGE: docker
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localstack:4566
+      AWS_ENDPOINT_URL_DYNAMODB: http://localstack:4566
+      AWS_ENDPOINT_URL_S3: http://localstack:4566
+      AWS_ENDPOINT_URL_SECRETSMANAGER: http://localstack:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      E2E_AUTH_ENABLED: 'true'
+      E2E_AUTH_SECRET: e2e-docker-preview-secret
+    expose:
+      - '3000'
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://127.0.0.1:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/preview/Dockerfile
+      target: preview-frontend
+    container_name: equiptrack-preview-frontend
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - '4280:80'
+
+volumes:
+  equiptrack-preview-localstack:

--- a/docker/preview/Dockerfile
+++ b/docker/preview/Dockerfile
@@ -1,0 +1,46 @@
+# Full-stack preview image build (shared builder). Targets: preview-backend, preview-frontend
+# Build: docker compose -f docker-compose.preview.yml build
+
+FROM node:20-bookworm AS builder
+
+WORKDIR /workspace
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# SPA talks to /api on the same origin (nginx proxies to backend)
+ENV RUNTIME_USE_SAME_ORIGIN_FOR_API=true
+ENV E2E_AUTH_ENABLED=true
+RUN node scripts/write-runtime-config.js http://127.0.0.1:3000
+
+RUN npx nx run backend:build:development --skip-nx-cache
+RUN npx nx run frontend:build:development --skip-nx-cache
+
+# --- Backend: LocalStack + local HTTP server (Lambda-style router)
+FROM node:20-bookworm-slim AS preview-backend
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /workspace/dist/apps/backend/ ./
+RUN npm ci --omit=dev
+COPY --from=builder /workspace/scripts ./scripts
+COPY docker/preview/backend-entrypoint.sh /usr/local/bin/preview-backend-entrypoint.sh
+RUN chmod +x /usr/local/bin/preview-backend-entrypoint.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/preview-backend-entrypoint.sh"]
+
+# --- Frontend: static SPA + nginx reverse proxy to backend
+FROM nginx:1.27-alpine AS preview-frontend
+
+COPY --from=builder /workspace/dist/apps/frontend/browser /usr/share/nginx/html
+COPY docker/preview/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/docker/preview/backend-entrypoint.sh
+++ b/docker/preview/backend-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+export STAGE="${STAGE:-docker}"
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-test}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
+export AWS_ENDPOINT_URL="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+export AWS_ENDPOINT_URL_DYNAMODB="${AWS_ENDPOINT_URL_DYNAMODB:-$AWS_ENDPOINT_URL}"
+export AWS_ENDPOINT_URL_S3="${AWS_ENDPOINT_URL_S3:-$AWS_ENDPOINT_URL}"
+export AWS_ENDPOINT_URL_SECRETSMANAGER="${AWS_ENDPOINT_URL_SECRETSMANAGER:-$AWS_ENDPOINT_URL}"
+
+export E2E_AUTH_ENABLED="${E2E_AUTH_ENABLED:-true}"
+export E2E_AUTH_SECRET="${E2E_AUTH_SECRET:-e2e-docker-preview-secret}"
+export LOCAL_HTTP_SERVER=true
+export BACKEND_LISTEN_HOST="${BACKEND_LISTEN_HOST:-0.0.0.0}"
+export BACKEND_PORT="${BACKEND_PORT:-3000}"
+
+LS_URL="${AWS_ENDPOINT_URL}"
+echo "[preview-backend] Waiting for LocalStack at ${LS_URL}..."
+i=0
+while [ "$i" -lt 60 ]; do
+  if curl -fsS "${LS_URL}/_localstack/health" > /dev/null 2>&1; then
+    break
+  fi
+  i=$((i + 1))
+  sleep 2
+done
+
+if ! curl -fsS "${LS_URL}/_localstack/health" > /dev/null 2>&1; then
+  echo "[preview-backend] LocalStack did not become ready in time" >&2
+  exit 1
+fi
+
+echo "[preview-backend] Provisioning DynamoDB, S3, secrets, seed data..."
+node scripts/setup-local-e2e.js
+
+echo "[preview-backend] Starting HTTP API on ${BACKEND_LISTEN_HOST}:${BACKEND_PORT}"
+exec node main.js

--- a/docker/preview/nginx.conf
+++ b/docker/preview/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
+
+    location /api/ {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=300";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docs/docker-preview.md
+++ b/docs/docker-preview.md
@@ -1,0 +1,54 @@
+# Docker full-stack preview (LocalStack)
+
+Run the **Angular app + local HTTP backend + LocalStack** (DynamoDB, S3, Secrets Manager) in Docker — no AWS account required. The UI is served on **port 4280**; the browser calls **`/api/...`** on the same origin and nginx proxies to the backend.
+
+## Prerequisites
+
+- Docker with Compose v2
+- Nothing required on ports **4280** or **4566** (change the host mapping in `docker-compose.preview.yml` if needed)
+
+## Start
+
+```bash
+npm run docker:preview:up
+```
+
+Open [http://localhost:4280](http://localhost:4280).
+
+First start **builds images** (Nx build inside Docker); expect several minutes.
+
+## Stop
+
+```bash
+npm run docker:preview:down
+```
+
+Remove volumes (clean database / LocalStack data):
+
+```bash
+npm run docker:preview:reset
+```
+
+## Authentication
+
+The preview stack enables **`/api/auth/e2e-login`** (same mechanism as local E2E). Default secret in compose: **`e2e-docker-preview-secret`**.
+
+Example (mint JWT, then set `localStorage` in the browser as in `AGENTS.md`):
+
+```bash
+curl -s -X POST http://localhost:4280/api/auth/e2e-login \
+  -H 'Content-Type: application/json' \
+  -H 'x-e2e-secret: e2e-docker-preview-secret' \
+  -d '{"userId":"user-e2e-admin","orgIdToRole":{"org-e2e-main":"admin"}}'
+```
+
+Seeded users and org match [local E2E fixtures](./local-e2e.md#seeded-identities).
+
+Override the secret by setting `E2E_AUTH_SECRET` for the `backend` service in `docker-compose.preview.yml` (keep frontend/runtime in sync only if you add a custom login path; e2e-login uses the backend env).
+
+## Implementation notes
+
+- **Backend** listens on `0.0.0.0` via `BACKEND_LISTEN_HOST` (set in the image entrypoint).
+- **Runtime config** uses `useSameOriginForApi: true` so `ApiService` calls `/api/...` relative to the nginx host.
+- **Stage** is `docker` → DynamoDB tables are suffixed `-docker` inside LocalStack.
+- **Images** are defined in `docker/preview/Dockerfile` (multi-stage: builder, `preview-backend`, `preview-frontend`).

--- a/docs/local-e2e.md
+++ b/docs/local-e2e.md
@@ -11,6 +11,10 @@ This setup provisions local AWS dependencies used by backend E2E flows:
 - Docker
 - Node/npm dependencies installed (`npm ci`)
 
+## Docker full-stack preview (alternative)
+
+To run **frontend + backend + LocalStack** entirely in containers (no local `nx serve`), see [docker-preview.md](./docker-preview.md) (`npm run docker:preview:up`).
+
 ## Start and provision
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "backend:serve:e2e-local": "env STAGE=local AWS_REGION=us-east-1 AWS_ENDPOINT_URL=http://localhost:4566 AWS_ENDPOINT_URL_DYNAMODB=http://localhost:4566 AWS_ENDPOINT_URL_S3=http://localhost:4566 AWS_ENDPOINT_URL_SECRETSMANAGER=http://localhost:4566 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test E2E_AUTH_ENABLED=true E2E_AUTH_SECRET=e2e-local-secret BACKEND_PORT=3000 LOCAL_HTTP_SERVER=true bash -c \"nx run backend:build:development && node dist/apps/backend/main.js\"",
     "frontend:serve:e2e-local": "node scripts/write-runtime-config.js http://localhost:3000 && nx run frontend:serve",
     "e2e:local:test": "npm run e2e:local:prepare && npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never E2E_SKIP_LOCAL_E2E_ENSURE=true npx nx run frontend-e2e:e2e-local-core",
+    "docker:preview:build": "docker compose -f docker-compose.preview.yml build",
+    "docker:preview:up": "docker compose -f docker-compose.preview.yml up -d --build",
+    "docker:preview:down": "docker compose -f docker-compose.preview.yml down",
+    "docker:preview:reset": "docker compose -f docker-compose.preview.yml down -v",
     "e2e:deployed:test": "npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never npx nx run frontend-e2e:e2e-deployed-core",
     "precommit": "nx affected -t lint,test --uncommitted --nxBail --exclude=frontend-e2e,backend-e2e && npm run validate:translations",
     "prepare": "husky"

--- a/scripts/write-runtime-config.js
+++ b/scripts/write-runtime-config.js
@@ -12,13 +12,22 @@ const runtimeConfigPath = path.join(
   'runtime-config.json'
 );
 
-const content = JSON.stringify(
-  {
-    apiUrl,
-  },
-  null,
-  2
-);
+function useSameOriginForApi() {
+  return (
+    String(process.env.RUNTIME_USE_SAME_ORIGIN_FOR_API || '').toLowerCase() ===
+    'true'
+  );
+}
+
+const payload = useSameOriginForApi()
+  ? { useSameOriginForApi: true }
+  : { apiUrl };
+
+const content = JSON.stringify(payload, null, 2);
 
 fs.writeFileSync(runtimeConfigPath, `${content}\n`, 'utf-8');
-console.log(`[write-runtime-config] runtime apiUrl set to ${apiUrl}`);
+if (useSameOriginForApi()) {
+  console.log('[write-runtime-config] useSameOriginForApi=true (API via /api on current host)');
+} else {
+  console.log(`[write-runtime-config] runtime apiUrl set to ${apiUrl}`);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Docker Compose** stack to run **LocalStack + backend (local HTTP server) + nginx-served Angular** for feature testing without AWS.

## Usage

```bash
npm run docker:preview:up
```

Open **http://localhost:4280**. API is same-origin via **`/api/*`** (nginx proxies to the backend).

See [docs/docker-preview.md](https://github.com/NetanelAlbert/EquipTrack/blob/cursor/docker-preview-localstack-1a60/docs/docker-preview.md) for stop/reset and E2E login (`e2e-docker-preview-secret` by default).

## Key changes

- `docker-compose.preview.yml` — LocalStack, `preview-backend`, `preview-frontend`
- `docker/preview/Dockerfile` — multi-stage build (Nx in builder; backend `npm ci` from generated `dist/apps/backend/package.json`; nginx + static browser bundle)
- `BACKEND_LISTEN_HOST` support in `local-http-server.ts` (bind `0.0.0.0` in containers)
- `runtime-config.json` may set `useSameOriginForApi: true` when `RUNTIME_USE_SAME_ORIGIN_FOR_API=true` in `write-runtime-config.js` (Docker build)
- npm scripts: `docker:preview:build`, `docker:preview:up`, `docker:preview:down`, `docker:preview:reset`
- `.dockerignore` to keep build context smaller

Complements the existing `docker-compose.e2e.yml` + `npm run e2e:local:*` flow by packaging app + API + seed in one compose file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-617f1716-0793-480f-ab07-7572df4b1a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-617f1716-0793-480f-ab07-7572df4b1a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

