### PR TITLE
fix(ci): stop LocalStack from triggering Docker Hub rate limits (429)

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -11,7 +11,9 @@ services:
       - PERSISTENCE=1
     volumes:
       - localstack-data:/var/lib/localstack
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Do not mount docker.sock: LocalStack would use the host Docker daemon and can
+      # pull Lambda/runtime images from Docker Hub, hitting anonymous rate limits (429) in CI.
+      # E2E only enables dynamodb,s3,secretsmanager — no container-backed services needed.
     healthcheck:
       test: ['CMD', 'bash', '-c', 'curl -fsS http://localhost:4566/_localstack/health > /dev/null']
       interval: 5s

--- a/docs/local-e2e.md
+++ b/docs/local-e2e.md
@@ -115,6 +115,7 @@ Deployed runs use the GitHub Environment secret `E2E_AUTH_SECRET` plus URLs from
 
 ## Troubleshooting
 
+- **Docker Hub `toomanyrequests` (429) in CI or locally**: The compose file does not mount the host Docker socket, so LocalStack does not pull extra images for Lambda/container features. If you customize compose to mount `docker.sock` and see rate limits, use a Docker Hub login (`docker login`) or a registry mirror — do not store container images in the app repo or in S3 for this; use a registry with authenticated or higher pull limits.
 - **LocalStack not healthy**: Run `npm run e2e:local:stack:down` then `npm run e2e:local:prepare`, or `npm run e2e:local:stack:reset` for a clean volume.
 - **Port 4566 / 3000 / 4200 in use**: Stop conflicting processes or adjust compose ports / `BACKEND_BASE_URL` / `BASE_URL` consistently in Playwright env.
 - **Playwright “browser not installed”**: Run `npm run e2e:local:install-browsers` or `npx playwright install chromium`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The LocalStack E2E job failed with **Too Many Requests** when pulling images. The compose stack already uses `public.ecr.aws/localstack/localstack:3.8` (not Docker Hub), but mounting **`/var/run/docker.sock`** lets LocalStack use the host Docker daemon and pull **additional** images (e.g. Lambda/container runtimes), which often come from **Docker Hub** and hit **anonymous pull rate limits** on GitHub-hosted runners.

## Change

- Remove the `docker.sock` volume from `docker-compose.e2e.yml`. Our LocalStack `SERVICES` are only `dynamodb`, `s3`, and `secretsmanager` — no container-backed emulators are required for this project’s E2E flow.

## Best practices (repo vs S3 vs “something else”)

- **Do not** check Docker images into the git repo or treat S3 as a primary image registry for CI pulls; use an **OCI registry** (Docker Hub with login, GHCR, ECR Public, etc.) and **authenticate** or choose images hosted on registries with suitable limits for your traffic.
- For CI: prefer **images already on registries that behave well for automation** (we already use ECR Public for LocalStack) and **avoid unnecessary host-Docker access** so LocalStack does not trigger extra pulls.

## Docs

- Added a short troubleshooting note in `docs/local-e2e.md` for anyone who reintroduces `docker.sock` or custom LocalStack features.

## Verification

- `docker compose -f docker-compose.e2e.yml config` succeeds locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac11453b-00ba-47f5-8be6-a177c2251680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac11453b-00ba-47f5-8be6-a177c2251680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

