### PR TITLE
feat: AWS PR preview environments + Docker LocalStack stack (#155)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.git
+.github
+.nx
+coverage
+**/.angular/cache
+tmp
+*.log
+.env
+.env.*
+!.env.example

--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -1,0 +1,34 @@
+name: Cleanup PR preview
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: pr-preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: il-central-1
+  STAGE: pr-${{ github.event.pull_request.number }}
+  BASE_DOMAIN: equip-track.com
+
+jobs:
+  teardown:
+    name: Remove PR preview AWS resources
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Teardown preview stack and data
+        run: node scripts/pr-preview-teardown.js

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -13,6 +13,11 @@
 # Optional: NX_CLOUD_ACCESS_TOKEN (repository or environment)
 name: Deploy PR preview
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -194,8 +199,10 @@ jobs:
             aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/assets/runtime-config.json" "/*"
           fi
 
+      # Fork PRs: token may be read-only; deployment still succeeds without a comment.
       - name: Comment preview URLs on PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,6 +1,7 @@
 # Isolated full-stack preview per PR: STAGE=pr-<number>, unique hostname under BASE_DOMAIN.
 # Required repo secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, API_GATEWAY_REGIONAL_CERTIFICATE_ARN,
 #   PR_PREVIEW_SEED_PASSWORD (shared password for all seeded preview users — not committed).
+#   Until this secret exists, the deploy job is skipped so PR checks stay green.
 # Optional: NX_CLOUD_ACCESS_TOKEN
 name: Deploy PR preview
 

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,181 @@
+# Isolated full-stack preview per PR: STAGE=pr-<number>, unique hostname under BASE_DOMAIN.
+# Required repo secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, API_GATEWAY_REGIONAL_CERTIFICATE_ARN,
+#   PR_PREVIEW_SEED_PASSWORD (shared password for all seeded preview users — not committed).
+# Optional: NX_CLOUD_ACCESS_TOKEN
+name: Deploy PR preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [develop, main]
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: il-central-1
+  NODE_VERSION: '20'
+  NX_NO_CLOUD: 'true'
+  NX_BRANCH: ${{ github.event.repository.default_branch || 'develop' }}
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  STAGE: pr-${{ github.event.pull_request.number }}
+  BASE_DOMAIN: equip-track.com
+  PR_PREVIEW_SEED_PASSWORD: ${{ secrets.PR_PREVIEW_SEED_PASSWORD }}
+  RUNTIME_FEATURE_PREVIEW_LOGIN: 'true'
+  E2E_AUTH_ENABLED: 'false'
+
+jobs:
+  deploy-preview:
+    if: github.event.pull_request.draft == false
+    name: Deploy PR preview stack
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Validate preview password secret
+        run: |
+          if [ -z "${PR_PREVIEW_SEED_PASSWORD}" ]; then
+            echo "::error::PR_PREVIEW_SEED_PASSWORD secret is not set (required for preview DB seeding)"
+            exit 1
+          fi
+
+      - name: Prepare deployment
+        run: |
+          node scripts/deployment-status-tracker.js track prepare started
+          node scripts/prepare-deployment.js
+          node scripts/deployment-status-tracker.js track prepare success
+
+      - name: Hydrate backend infra from AWS
+        run: node scripts/hydrate-backend-infra.js
+
+      - name: Build backend
+        run: npx nx build backend --configuration=development
+
+      - name: Create DynamoDB tables
+        run: |
+          node scripts/deployment-status-tracker.js track dynamodb started
+          node scripts/create-dynamodb-tables.js
+          node scripts/deployment-status-tracker.js track dynamodb success
+
+      - name: Seed preview data (E2E fixtures + password hashes)
+        run: |
+          node scripts/deployment-status-tracker.js track seed-e2e started
+          node scripts/seed-e2e-data.js
+          node scripts/deployment-status-tracker.js track seed-e2e success
+
+      - name: Create Lambda packages
+        run: |
+          node scripts/deployment-status-tracker.js track lambda-packages started
+          node scripts/create-lambda-packages.js
+          node scripts/deployment-status-tracker.js track lambda-packages success
+
+      - name: Deploy API (SAM)
+        env:
+          API_GATEWAY_REGIONAL_CERTIFICATE_ARN: ${{ secrets.API_GATEWAY_REGIONAL_CERTIFICATE_ARN }}
+          E2E_AUTH_SECRET: ''
+        run: |
+          node scripts/deployment-status-tracker.js track api-gateway started
+          node scripts/deploy-sam-api.js
+          node scripts/deployment-status-tracker.js track api-gateway success
+
+      - name: Build frontend
+        run: npx nx build frontend --configuration=development
+
+      - name: Deploy frontend (fast path)
+        id: frontend
+        continue-on-error: true
+        run: node scripts/deploy-frontend-fast.js
+
+      - name: Deploy frontend (full setup)
+        if: steps.frontend.outcome == 'failure'
+        run: |
+          node scripts/deploy-frontend.js
+          node scripts/setup-cloudfront.js
+
+      - name: Setup frontend custom domain
+        run: node scripts/setup-frontend-custom-domain.js
+
+      - name: Sync runtime-config.json to S3 (API URL + preview login flag)
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const {
+            syncRuntimeConfigToS3,
+            resolveRuntimeApiUrl,
+          } = require('./scripts/write-runtime-config.js');
+          const stage = process.env.STAGE;
+          const di = JSON.parse(fs.readFileSync('deployment-info.json', 'utf8'));
+          const apiUrl = resolveRuntimeApiUrl(di);
+          if (!apiUrl) {
+            console.error('Could not resolve API URL from deployment-info.json');
+            process.exit(1);
+          }
+          process.env.RUNTIME_FEATURE_PREVIEW_LOGIN = 'true';
+          syncRuntimeConfigToS3(`equip-track-frontend-${stage}`, apiUrl);
+          NODE
+
+      - name: Invalidate CloudFront for runtime config
+        run: |
+          DIST_ID=$(jq -r '.frontend.cloudfront.distributionId // empty' deployment-info.json)
+          if [[ -n "$DIST_ID" ]]; then
+            aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/assets/runtime-config.json" "/*"
+          fi
+
+      - name: Comment preview URLs on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const stage = `pr-${{ github.event.pull_request.number }}`;
+            const base = 'equip-track.com';
+            const body = `### PR preview deployed\n\n- **App:** https://${stage}.${base}\n- **API:** https://${stage}-api.${base}\n\n**Sign-in:** Use **email + password** on the login page (not Google). Seeded emails are unchanged (e.g. \`e2e.admin@example.com\`); the **shared preview password** is in the \`PR_PREVIEW_SEED_PASSWORD\` repository secret (ask a maintainer).\n`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = '<!-- equiptrack-pr-preview-bot -->';
+            const existing = comments.find((c) =>
+              c.user.type === 'Bot' && c.body.includes(marker)
+            );
+            const fullBody = marker + '\n' + body;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: fullBody,
+              });
+            }
+
+      - name: Deployment report
+        if: always()
+        run: node scripts/deployment-status-tracker.js report

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,17 +1,35 @@
 # Isolated full-stack preview per PR: STAGE=pr-<number>, unique hostname under BASE_DOMAIN.
-# Required repo secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, API_GATEWAY_REGIONAL_CERTIFICATE_ARN,
-#   PR_PREVIEW_SEED_PASSWORD (shared password for all seeded preview users — not committed).
-#   Until this secret exists, the deploy job is skipped so PR checks stay green.
-# Optional: NX_CLOUD_ACCESS_TOKEN
+#
+# Secrets (GitHub → Settings → Environments → development → Environment secrets recommended):
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, API_GATEWAY_REGIONAL_CERTIFICATE_ARN,
+#   PR_PREVIEW_SEED_PASSWORD (shared password for seeded preview users — not in git).
+#
+# IMPORTANT: Put PR_PREVIEW_SEED_PASSWORD on the same "development" environment as the other
+# deploy secrets. Job-level `if: secrets.*` does NOT see environment-only secrets, which
+# caused skipped/failed runs before the two-job pattern below.
+#
+# Manual validation: Actions → "Deploy PR preview" → Run workflow (PR number + optional ref).
+#
+# Optional: NX_CLOUD_ACCESS_TOKEN (repository or environment)
 name: Deploy PR preview
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [develop, main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number (preview stage will be pr-<number>)'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref to build and deploy (branch, tag, or SHA)'
+        required: false
+        default: 'develop'
 
 concurrency:
-  group: pr-preview-${{ github.event.pull_request.number }}
+  group: pr-preview-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 env:
@@ -20,27 +38,63 @@ env:
   NX_NO_CLOUD: 'true'
   NX_BRANCH: ${{ github.event.repository.default_branch || 'develop' }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-  STAGE: pr-${{ github.event.pull_request.number }}
   BASE_DOMAIN: equip-track.com
-  PR_PREVIEW_SEED_PASSWORD: ${{ secrets.PR_PREVIEW_SEED_PASSWORD }}
   RUNTIME_FEATURE_PREVIEW_LOGIN: 'true'
   E2E_AUTH_ENABLED: 'false'
 
 jobs:
-  deploy-preview:
-    # Skip until maintainers add PR_PREVIEW_SEED_PASSWORD (required for hashed preview logins).
-    if: >
-      github.event.pull_request.draft == false &&
-      secrets.PR_PREVIEW_SEED_PASSWORD != ''
-    name: Deploy PR preview stack
+  # Resolve environment secrets (incl. PR_PREVIEW_SEED_PASSWORD) before gating deploy.
+  check-preview-secrets:
+    name: Check preview prerequisites
     runs-on: ubuntu-latest
     environment: development
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    outputs:
+      has_seed_password: ${{ steps.gate.outputs.has_seed_password }}
+      stage: ${{ steps.stage.outputs.stage }}
+
+    steps:
+      - name: Determine stage name
+        id: stage
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            N="${{ github.event.inputs.pr_number }}"
+          else
+            N="${{ github.event.pull_request.number }}"
+          fi
+          echo "stage=pr-${N}" >> "$GITHUB_OUTPUT"
+
+      - name: Check PR_PREVIEW_SEED_PASSWORD is available
+        id: gate
+        env:
+          PR_PREVIEW_SEED_PASSWORD: ${{ secrets.PR_PREVIEW_SEED_PASSWORD }}
+        run: |
+          if [ -n "${PR_PREVIEW_SEED_PASSWORD}" ]; then
+            echo "has_seed_password=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_seed_password=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR_PREVIEW_SEED_PASSWORD is empty. Add it under Settings → Environments → **development** → Environment secrets (same place as AWS keys). Repository-only secrets are also supported if you remove \`environment: development\` from jobs."
+          fi
+
+  deploy-preview:
+    name: Deploy PR preview stack
+    runs-on: ubuntu-latest
+    needs: check-preview-secrets
+    if: needs.check-preview-secrets.outputs.has_seed_password == 'true'
+    environment: development
+
+    env:
+      STAGE: ${{ needs.check-preview-secrets.outputs.stage }}
+      PR_PREVIEW_SEED_PASSWORD: ${{ secrets.PR_PREVIEW_SEED_PASSWORD }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -141,12 +195,13 @@ jobs:
           fi
 
       - name: Comment preview URLs on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const stage = `pr-${{ github.event.pull_request.number }}`;
             const base = 'equip-track.com';
-            const body = `### PR preview deployed\n\n- **App:** https://${stage}.${base}\n- **API:** https://${stage}-api.${base}\n\n**Sign-in:** Use **email + password** on the login page (not Google). Seeded emails are unchanged (e.g. \`e2e.admin@example.com\`); the **shared preview password** is in the \`PR_PREVIEW_SEED_PASSWORD\` repository secret (ask a maintainer).\n`;
+            const body = `### PR preview deployed\n\n- **App:** https://${stage}.${base}\n- **API:** https://${stage}-api.${base}\n\n**Sign-in:** Use **email + password** on the login page (not Google). Seeded emails are unchanged (e.g. \`e2e.admin@example.com\`); the **shared preview password** is the \`PR_PREVIEW_SEED_PASSWORD\` value from the **development** environment secret.\n`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -27,7 +27,10 @@ env:
 
 jobs:
   deploy-preview:
-    if: github.event.pull_request.draft == false
+    # Skip until maintainers add PR_PREVIEW_SEED_PASSWORD (required for hashed preview logins).
+    if: >
+      github.event.pull_request.draft == false &&
+      secrets.PR_PREVIEW_SEED_PASSWORD != ''
     name: Deploy PR preview stack
     runs-on: ubuntu-latest
     environment: development
@@ -53,13 +56,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Validate preview password secret
-        run: |
-          if [ -z "${PR_PREVIEW_SEED_PASSWORD}" ]; then
-            echo "::error::PR_PREVIEW_SEED_PASSWORD secret is not set (required for preview DB seeding)"
-            exit 1
-          fi
 
       - name: Prepare deployment
         run: |

--- a/apps/backend/src/api/auth/feature-preview-password-crypto.ts
+++ b/apps/backend/src/api/auth/feature-preview-password-crypto.ts
@@ -1,0 +1,45 @@
+import { scrypt, timingSafeEqual } from 'crypto';
+import { promisify } from 'util';
+
+const PREFIX = 'scrypt1';
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const;
+
+const scryptAsync = promisify(scrypt) as (
+  password: string | Buffer,
+  salt: string | Buffer,
+  keylen: number,
+  options: typeof SCRYPT_PARAMS
+) => Promise<Buffer>;
+
+export async function verifyFeaturePreviewPassword(
+  password: string,
+  stored: string
+): Promise<boolean> {
+  if (!stored?.startsWith(`${PREFIX}.`)) {
+    return false;
+  }
+  const parts = stored.split('.');
+  if (parts.length !== 3) {
+    return false;
+  }
+  let salt: Buffer;
+  let expected: Buffer;
+  try {
+    salt = Buffer.from(parts[1], 'base64');
+    expected = Buffer.from(parts[2], 'base64');
+  } catch {
+    return false;
+  }
+  if (salt.length === 0 || expected.length === 0) {
+    return false;
+  }
+  const hash = await scryptAsync(password, salt, expected.length, SCRYPT_PARAMS);
+  try {
+    return timingSafeEqual(
+      new Uint8Array(hash),
+      new Uint8Array(expected)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/backend/src/api/auth/feature-preview-password.spec.ts
+++ b/apps/backend/src/api/auth/feature-preview-password.spec.ts
@@ -1,0 +1,107 @@
+import { handler } from './feature-preview-password';
+import { UsersAndOrganizationsAdapter } from '../../db/tables/users-and-organizations.adapter';
+import { UserState } from '@equip-track/shared';
+import { verifyFeaturePreviewPassword } from './feature-preview-password-crypto';
+
+jest.mock('./feature-preview-password-crypto', () => ({
+  verifyFeaturePreviewPassword: jest.fn(),
+}));
+
+jest.mock('../../services/jwt.service', () => ({
+  JwtService: jest.fn().mockImplementation(() => ({
+    generateToken: jest.fn().mockResolvedValue('test-jwt'),
+  })),
+}));
+
+jest.mock('../../db/tables/users-and-organizations.adapter');
+
+const mockVerify = verifyFeaturePreviewPassword as jest.MockedFunction<
+  typeof verifyFeaturePreviewPassword
+>;
+
+const mockAdapter = {
+  getUserByEmail: jest.fn(),
+  getUserDbRecord: jest.fn(),
+};
+
+describe('feature-preview-password handler', () => {
+  const origStage = process.env.STAGE;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STAGE = 'pr-999';
+    mockVerify.mockResolvedValue(true);
+    (UsersAndOrganizationsAdapter as jest.Mock).mockImplementation(
+      () => mockAdapter
+    );
+  });
+
+  afterAll(() => {
+    process.env.STAGE = origStage;
+  });
+
+  it('rejects when stage is not a PR preview', async () => {
+    process.env.STAGE = 'dev';
+    await expect(
+      handler({ email: 'a@b.com', password: 'x' }, {})
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('returns JWT when password verifies', async () => {
+    mockAdapter.getUserByEmail.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        email: 'a@b.com',
+        name: 'A',
+        state: UserState.Active,
+      },
+      userInOrganizations: [
+        { organizationId: 'org-1', userId: 'user-1', role: 'admin' },
+      ],
+    });
+    mockAdapter.getUserDbRecord.mockResolvedValue({
+      PK: 'USER#user-1',
+      SK: 'METADATA',
+      dbItemType: 'USER',
+      id: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      state: UserState.Active,
+      featurePreviewPasswordHash: 'scrypt1.x.y',
+    });
+
+    const res = await handler(
+      { email: 'a@b.com', password: 'secret' },
+      {}
+    );
+    expect(res.status).toBe(true);
+    expect(res.jwt).toBe('test-jwt');
+    expect(mockVerify).toHaveBeenCalledWith('secret', 'scrypt1.x.y');
+  });
+
+  it('rejects when user has no preview password hash', async () => {
+    mockAdapter.getUserByEmail.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        email: 'a@b.com',
+        name: 'A',
+        state: UserState.Active,
+      },
+      userInOrganizations: [],
+    });
+    mockAdapter.getUserDbRecord.mockResolvedValue({
+      PK: 'USER#user-1',
+      SK: 'METADATA',
+      dbItemType: 'USER',
+      id: 'user-1',
+      email: 'a@b.com',
+      name: 'A',
+      state: UserState.Active,
+    });
+
+    await expect(
+      handler({ email: 'a@b.com', password: 'secret' }, {})
+    ).rejects.toMatchObject({ statusCode: 401 });
+    expect(mockVerify).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/api/auth/feature-preview-password.ts
+++ b/apps/backend/src/api/auth/feature-preview-password.ts
@@ -1,0 +1,89 @@
+import { Auth, UserRole, UserState } from '@equip-track/shared';
+import { APIGatewayProxyEventPathParameters } from 'aws-lambda';
+import {
+  badRequest,
+  forbidden,
+  isErrorResponse,
+  unauthorized,
+} from '../responses';
+import { JwtService } from '../../services/jwt.service';
+import { UsersAndOrganizationsAdapter } from '../../db/tables/users-and-organizations.adapter';
+import { verifyFeaturePreviewPassword } from './feature-preview-password-crypto';
+
+function isFeaturePreviewStage(stage: string | undefined): boolean {
+  return Boolean(stage && /^pr-\d+$/i.test(stage.trim()));
+}
+
+export const handler = async (
+  req: Auth.FeaturePreviewPasswordAuthRequest,
+  _pathParams: APIGatewayProxyEventPathParameters
+): Promise<Auth.FeaturePreviewPasswordAuthResponse> => {
+  void _pathParams;
+  try {
+    const stage = (process.env.STAGE || '').trim();
+    if (!isFeaturePreviewStage(stage)) {
+      throw forbidden('Feature preview authentication is not available');
+    }
+
+    const emailRaw = req?.email;
+    const password = req?.password;
+    if (
+      typeof emailRaw !== 'string' ||
+      typeof password !== 'string' ||
+      !emailRaw.trim() ||
+      !password
+    ) {
+      throw badRequest('Email and password are required');
+    }
+
+    const email = emailRaw.trim().toLowerCase();
+    const usersAdapter = new UsersAndOrganizationsAdapter();
+    const userBundle = await usersAdapter.getUserByEmail(email);
+
+    if (!userBundle) {
+      throw unauthorized('Invalid email or password');
+    }
+
+    if (userBundle.user.state === UserState.Disabled) {
+      throw forbidden(
+        'Your account has been disabled. Please contact your administrator.'
+      );
+    }
+
+    const userRow = await usersAdapter.getUserDbRecord(userBundle.user.id);
+    const storedHash = userRow?.featurePreviewPasswordHash;
+    if (!storedHash) {
+      throw unauthorized('Invalid email or password');
+    }
+
+    const ok = await verifyFeaturePreviewPassword(password, storedHash);
+    if (!ok) {
+      throw unauthorized('Invalid email or password');
+    }
+
+    const orgIdToRole = userBundle.userInOrganizations.reduce(
+      (acc, org) => {
+        acc[org.organizationId] = org.role;
+        return acc;
+      },
+      {} as Record<string, UserRole>
+    );
+
+    const jwtService = new JwtService();
+    const jwt = await jwtService.generateToken(
+      userBundle.user.id,
+      orgIdToRole
+    );
+
+    return {
+      status: true,
+      jwt,
+    };
+  } catch (error) {
+    if (isErrorResponse(error)) {
+      throw error;
+    }
+    console.error('[FEATURE_PREVIEW_PASSWORD_AUTH]', error);
+    throw badRequest('Authentication failed');
+  }
+};

--- a/apps/backend/src/api/handlers.ts
+++ b/apps/backend/src/api/handlers.ts
@@ -1,6 +1,7 @@
 import { endpointMetas, EndpointMeta, JwtPayload } from '@equip-track/shared';
 import { handler as googleAuthHandler } from './auth/google';
 import { handler as e2eAuthHandler } from './auth/e2e-login';
+import { handler as featurePreviewPasswordAuthHandler } from './auth/feature-preview-password';
 import { handler as getUsersHandler } from './admin/users/get';
 import { handler as setUserHandler } from './admin/users/set';
 import { handler as inviteUserHandler } from './admin/users/invite';
@@ -48,6 +49,7 @@ export const handlers: HandlersDefinition = {
   // Authentication
   googleAuth: googleAuthHandler,
   e2eAuth: e2eAuthHandler,
+  featurePreviewPasswordAuth: featurePreviewPasswordAuthHandler,
 
   // Admin Users
   getUsers: getUsersHandler,

--- a/apps/backend/src/db/models.ts
+++ b/apps/backend/src/db/models.ts
@@ -44,6 +44,8 @@ export interface ProductDb extends DbItem {
 export interface UserDb extends User, DbItem {
   // Optional Google sub ID for users who authenticated with Google
   googleSub?: string;
+  /** Argon2id hash for feature-preview email login (preview DynamoDB stages only) */
+  featurePreviewPasswordHash?: string;
 }
 
 /**

--- a/apps/backend/src/db/tables/users-and-organizations.adapter.ts
+++ b/apps/backend/src/db/tables/users-and-organizations.adapter.ts
@@ -126,7 +126,8 @@ export class UsersAndOrganizationsAdapter {
   private getUser(userDB: UserDb): User {
     // Destructure to exclude database-specific fields and keep only User fields
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { PK, SK, dbItemType, googleSub, ...user } = userDB;
+    const { PK, SK, dbItemType, googleSub, featurePreviewPasswordHash, ...user } =
+      userDB;
     return user;
   }
 
@@ -385,6 +386,21 @@ export class UsersAndOrganizationsAdapter {
       return undefined;
     }
     return this.getUser(result.Item as UserDb);
+  }
+
+  /**
+   * Load raw user row (includes DB-only fields such as feature preview password hash).
+   */
+  async getUserDbRecord(userId: string): Promise<UserDb | undefined> {
+    const command = new GetCommand({
+      TableName: this.tableName,
+      Key: this.getUserKey(userId),
+    });
+    const result = await this.docClient.send(command);
+    if (!result.Item) {
+      return undefined;
+    }
+    return result.Item as UserDb;
   }
 
   async getUserInOrganization(

--- a/apps/backend/src/local-http-server.ts
+++ b/apps/backend/src/local-http-server.ts
@@ -196,6 +196,7 @@ async function invokeLambdaHandler(
 
 export async function startLocalHttpServer(): Promise<void> {
   const port = Number(process.env.BACKEND_PORT || 3000);
+  const listenHost = process.env.BACKEND_LISTEN_HOST?.trim() || undefined;
 
   const server = createServer(async (req, res) => {
     const method = (req.method || 'GET').toUpperCase();
@@ -243,10 +244,17 @@ export async function startLocalHttpServer(): Promise<void> {
     }
   });
 
-  await new Promise<void>((resolve) => {
-    server.listen(port, () => {
-      console.log(`[local-http-server] listening on http://localhost:${port}`);
+  await new Promise<void>((resolve, reject) => {
+    const onListen = () => {
+      const where = listenHost ? `${listenHost}:${port}` : `localhost:${port}`;
+      console.log(`[local-http-server] listening on http://${where}`);
       resolve();
-    });
+    };
+    if (listenHost) {
+      server.listen(port, listenHost, onListen);
+    } else {
+      server.listen(port, onListen);
+    }
+    server.on('error', reject);
   });
 }

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -28,7 +28,12 @@
     "try-again": "Try Again",
     "try-again-detailed": "Try signing in again",
     "error": "Authentication Error",
-    "success": "Authentication Successful"
+    "success": "Authentication Successful",
+    "feature-preview-section": "Preview environment sign-in",
+    "feature-preview-hint": "This preview environment uses email and password. Use the shared preview password from your team (GitHub Actions secret), not your production Google account.",
+    "feature-preview-email-label": "Email",
+    "feature-preview-password-label": "Password",
+    "feature-preview-submit": "Sign in with email"
   },
   "common": {
     "close": "Close",

--- a/apps/frontend/src/assets/i18n/he.json
+++ b/apps/frontend/src/assets/i18n/he.json
@@ -28,7 +28,12 @@
     "try-again": "נסה שוב",
     "try-again-detailed": "נסה להתחבר שוב",
     "error": "שגיאת אימות",
-    "success": "האימות הצליח"
+    "success": "האימות הצליח",
+    "feature-preview-section": "התחברות לסביבת תצוגה מקדימה",
+    "feature-preview-hint": "בסביבת התצוגה המקדימה נעשה שימוש באימייל וסיסמה. השתמשו בסיסמה המשותפת מהצוות (סוד ב-GitHub Actions), לא בחשבון Google של הייצור.",
+    "feature-preview-email-label": "אימייל",
+    "feature-preview-password-label": "סיסמה",
+    "feature-preview-submit": "התחברות עם אימייל"
   },
   "common": {
     "close": "סגור",

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -2,7 +2,12 @@ import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { GoogleAuthRequest, GoogleAuthResponse } from '@equip-track/shared';
+import {
+  FeaturePreviewPasswordAuthRequest,
+  FeaturePreviewPasswordAuthResponse,
+  GoogleAuthRequest,
+  GoogleAuthResponse,
+} from '@equip-track/shared';
 import { ApiService } from './api.service';
 import { AuthStore } from '../store/auth.store';
 import { UserStore } from '../store/user.store';
@@ -39,6 +44,52 @@ export class AuthService {
       console.error('Auth initialization failed:', error);
       return false;
     }
+  }
+
+  authenticateWithFeaturePreviewPassword(
+    email: string,
+    password: string
+  ): Observable<FeaturePreviewPasswordAuthResponse> {
+    this.authStore.setAuthLoading();
+    const request: FeaturePreviewPasswordAuthRequest = { email, password };
+    return this.apiService.endpoints.featurePreviewPasswordAuth
+      .execute(request, {}, false)
+      .pipe(
+        map((response) => {
+          if (response.status && response.jwt) {
+            this.storeToken(response.jwt);
+            this.authStore.setToken(response.jwt);
+            this.validateAndCacheToken(response.jwt);
+            this.authStore.setAuthSuccess();
+          } else {
+            this.authStore.setAuthError('Invalid authentication response');
+          }
+          return response;
+        }),
+        catchError((error: unknown) => {
+          let errorMessage = 'Authentication failed';
+          const errObj = error as {
+            status?: number;
+            error?: { message?: string };
+            message?: string;
+          };
+          if (errObj?.status === 0) {
+            errorMessage = 'Network error. Please check your connection.';
+          } else if (errObj?.status && errObj.status >= 500) {
+            errorMessage = 'Server error. Please try again later.';
+          } else if (errObj?.status === 401 || errObj?.status === 403) {
+            errorMessage =
+              'Invalid email or password, or this login method is not available.';
+          } else if (errObj?.error?.message) {
+            errorMessage = errObj.error.message;
+          } else if (typeof errObj?.message === 'string') {
+            errorMessage = errObj.message;
+          }
+          this.authStore.setAuthError(errorMessage);
+          this.clearAuthenticationState();
+          throw error;
+        })
+      );
   }
 
   // Enhanced Google authentication with comprehensive error handling

--- a/apps/frontend/src/services/runtime-config.service.ts
+++ b/apps/frontend/src/services/runtime-config.service.ts
@@ -3,10 +3,21 @@ import { environment } from '../environments/environment';
 
 interface RuntimeConfig {
   apiUrl?: string;
+  featurePreviewLoginEnabled?: boolean;
 }
 
 function isRuntimeConfig(value: unknown): value is RuntimeConfig {
-  return typeof value === 'object' && value !== null;
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const o = value as Record<string, unknown>;
+  if (
+    o.featurePreviewLoginEnabled !== undefined &&
+    typeof o.featurePreviewLoginEnabled !== 'boolean'
+  ) {
+    return false;
+  }
+  return true;
 }
 
 /** True when apiUrl targets loopback or RFC1918 — unsafe from a public HTTPS origin (Chrome PNA, mixed behavior). */
@@ -56,6 +67,10 @@ export class RuntimeConfigService {
     return this.config.apiUrl || environment.apiUrl;
   }
 
+  get featurePreviewLoginEnabled(): boolean {
+    return this.config.featurePreviewLoginEnabled === true;
+  }
+
   async load(): Promise<void> {
     try {
       const response = await fetch('/assets/runtime-config.json', {
@@ -82,6 +97,12 @@ export class RuntimeConfigService {
             apiUrl: fileApiUrl,
           };
         }
+      }
+      if (configFromFile.featurePreviewLoginEnabled === true) {
+        this.config = {
+          ...this.config,
+          featurePreviewLoginEnabled: true,
+        };
       }
     } catch {
       // No-op fallback to environment config when runtime file is unavailable.

--- a/apps/frontend/src/services/runtime-config.service.ts
+++ b/apps/frontend/src/services/runtime-config.service.ts
@@ -3,10 +3,20 @@ import { environment } from '../environments/environment';
 
 interface RuntimeConfig {
   apiUrl?: string;
+  /** When true, API calls use the SPA origin (e.g. nginx proxies /api → backend). */
+  useSameOriginForApi?: boolean;
 }
 
 function isRuntimeConfig(value: unknown): value is RuntimeConfig {
-  return typeof value === 'object' && value !== null;
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const o = value as Record<string, unknown>;
+  const sameOrigin = o['useSameOriginForApi'];
+  if (sameOrigin !== undefined && typeof sameOrigin !== 'boolean') {
+    return false;
+  }
+  return true;
 }
 
 /** True when apiUrl targets loopback or RFC1918 — unsafe from a public HTTPS origin (Chrome PNA, mixed behavior). */
@@ -52,7 +62,12 @@ export class RuntimeConfigService {
     apiUrl: environment.apiUrl,
   };
 
+  private sameOriginApi = false;
+
   get apiUrl(): string {
+    if (this.sameOriginApi) {
+      return '';
+    }
     return this.config.apiUrl || environment.apiUrl;
   }
 
@@ -82,6 +97,13 @@ export class RuntimeConfigService {
             apiUrl: fileApiUrl,
           };
         }
+      }
+      if (configFromFile['useSameOriginForApi'] === true) {
+        this.sameOriginApi = true;
+        this.config = {
+          ...this.config,
+          apiUrl: '',
+        };
       }
     } catch {
       // No-op fallback to environment config when runtime file is unavailable.

--- a/apps/frontend/src/services/runtime-config.service.ts
+++ b/apps/frontend/src/services/runtime-config.service.ts
@@ -11,10 +11,8 @@ function isRuntimeConfig(value: unknown): value is RuntimeConfig {
     return false;
   }
   const o = value as Record<string, unknown>;
-  if (
-    o.featurePreviewLoginEnabled !== undefined &&
-    typeof o.featurePreviewLoginEnabled !== 'boolean'
-  ) {
+  const previewFlag = o['featurePreviewLoginEnabled'];
+  if (previewFlag !== undefined && typeof previewFlag !== 'boolean') {
     return false;
   }
   return true;

--- a/apps/frontend/src/ui/login/login.component.html
+++ b/apps/frontend/src/ui/login/login.component.html
@@ -33,7 +33,66 @@
           data-testid="signin-methods"
           [attr.aria-label]="'auth.google-signin-group' | translate"
         >
-        
+        @if (showFeaturePreviewLogin) {
+          <section
+            class="feature-preview-login"
+            data-testid="feature-preview-login"
+            [attr.aria-label]="'auth.feature-preview-section' | translate"
+          >
+            <p class="feature-preview-hint" role="note">
+              {{ 'auth.feature-preview-hint' | translate }}
+            </p>
+            <form
+              (ngSubmit)="onPreviewPasswordSubmit()"
+              class="feature-preview-form"
+            >
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>{{ 'auth.feature-preview-email-label' | translate }}</mat-label>
+                <input
+                  matInput
+                  type="email"
+                  name="previewEmail"
+                  [(ngModel)]="previewEmail"
+                  autocomplete="username"
+                  [attr.aria-label]="'auth.feature-preview-email-label' | translate"
+                  data-testid="feature-preview-email"
+                />
+              </mat-form-field>
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>{{ 'auth.feature-preview-password-label' | translate }}</mat-label>
+                <input
+                  matInput
+                  type="password"
+                  name="previewPassword"
+                  [(ngModel)]="previewPassword"
+                  autocomplete="current-password"
+                  [attr.aria-label]="'auth.feature-preview-password-label' | translate"
+                  data-testid="feature-preview-password"
+                />
+              </mat-form-field>
+              <button
+                mat-raised-button
+                color="primary"
+                type="submit"
+                class="full-width"
+                data-testid="feature-preview-submit"
+                [disabled]="authState().isLoading"
+                [attr.aria-label]="'auth.feature-preview-submit' | translate"
+              >
+                {{ 'auth.feature-preview-submit' | translate }}
+              </button>
+            </form>
+          </section>
+
+          <div
+            class="divider"
+            role="separator"
+            [attr.aria-label]="'auth.or-separator' | translate"
+          >
+            <span aria-hidden="true">{{ 'auth.or' | translate }}</span>
+          </div>
+        }
+
         <!-- Error message display -->
         @if (authState().error) {
           <div

--- a/apps/frontend/src/ui/login/login.component.scss
+++ b/apps/frontend/src/ui/login/login.component.scss
@@ -113,6 +113,27 @@
           opacity: 0.9;
         }
 
+        .feature-preview-login {
+          width: 100%;
+
+          .feature-preview-hint {
+            font-size: 14px;
+            line-height: 1.5;
+            color: var(--mat-text-secondary);
+            margin: 0 0 16px 0;
+          }
+
+          .feature-preview-form {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+
+            .full-width {
+              width: 100%;
+            }
+          }
+        }
+
         .sign-in-section {
           display: flex;
           justify-content: center;

--- a/apps/frontend/src/ui/login/login.component.ts
+++ b/apps/frontend/src/ui/login/login.component.ts
@@ -1,21 +1,30 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
 import { GoogleSignInComponent } from '../auth/google-sign-in.component';
 import { AuthService } from '../../services/auth.service';
 import { AuthStore } from '../../store/auth.store';
+import { RuntimeConfigService } from '../../services/runtime-config.service';
 import { GoogleAuthResponse } from '@equip-track/shared';
 
 @Component({
   selector: 'app-login',
   standalone: true,
   imports: [
+    FormsModule,
     MatCardModule,
     MatIconModule,
     MatProgressSpinnerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
     TranslateModule,
     GoogleSignInComponent,
   ],
@@ -26,15 +35,42 @@ export class LoginComponent implements OnInit {
   private router = inject(Router);
   private authService = inject(AuthService);
   private authStore = inject(AuthStore);
+  private runtimeConfig = inject(RuntimeConfigService);
 
   // Expose auth state for template
   authState = this.authStore.authenticationState;
 
-  ngOnInit() {
-    this.authService.initializeAuth();
+  /** Shown only when runtime-config.json enables feature preview login (PR preview deploys). */
+  showFeaturePreviewLogin = false;
+  previewEmail = '';
+  previewPassword = '';
+
+  async ngOnInit() {
+    await this.runtimeConfig.load();
+    this.showFeaturePreviewLogin = this.runtimeConfig.featurePreviewLoginEnabled;
+    await this.authService.initializeAuth();
     if (this.authStore.isAuthenticated()) {
       this.router.navigate(['/']);
     }
+  }
+
+  onPreviewPasswordSubmit(): void {
+    const email = this.previewEmail.trim();
+    if (!email || !this.previewPassword) {
+      return;
+    }
+    this.authService
+      .authenticateWithFeaturePreviewPassword(email, this.previewPassword)
+      .subscribe({
+        next: (response) => {
+          if (response.status) {
+            this.router.navigate(['/']);
+          }
+        },
+        error: (error: unknown) => {
+          console.error('Preview login failed:', error);
+        },
+      });
   }
 
   onGoogleSignIn(idToken: string) {

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -1,0 +1,70 @@
+# Local full-stack preview: LocalStack (DynamoDB, S3, Secrets Manager) + backend + nginx (Angular SPA).
+# Usage:
+#   npm run docker:preview:up
+# Open http://localhost:4280 — API is proxied at /api (same-origin; see runtime-config.json).
+#
+# Default E2E login secret: e2e-docker-preview-secret (override E2E_AUTH_SECRET in compose if needed).
+
+services:
+  localstack:
+    image: public.ecr.aws/localstack/localstack:3.8
+    container_name: equiptrack-preview-localstack
+    ports:
+      - '4566:4566'
+    environment:
+      - SERVICES=dynamodb,s3,secretsmanager
+      - AWS_DEFAULT_REGION=us-east-1
+      - DEBUG=0
+      - PERSISTENCE=1
+    volumes:
+      - equiptrack-preview-localstack:/var/lib/localstack
+    healthcheck:
+      test: ['CMD', 'bash', '-c', 'curl -fsS http://localhost:4566/_localstack/health > /dev/null']
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  backend:
+    build:
+      context: .
+      dockerfile: docker/preview/Dockerfile
+      target: preview-backend
+    container_name: equiptrack-preview-backend
+    depends_on:
+      localstack:
+        condition: service_healthy
+    environment:
+      STAGE: docker
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localstack:4566
+      AWS_ENDPOINT_URL_DYNAMODB: http://localstack:4566
+      AWS_ENDPOINT_URL_S3: http://localstack:4566
+      AWS_ENDPOINT_URL_SECRETSMANAGER: http://localstack:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      E2E_AUTH_ENABLED: 'true'
+      E2E_AUTH_SECRET: e2e-docker-preview-secret
+    expose:
+      - '3000'
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://127.0.0.1:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/preview/Dockerfile
+      target: preview-frontend
+    container_name: equiptrack-preview-frontend
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - '4280:80'
+
+volumes:
+  equiptrack-preview-localstack:

--- a/docker/preview/Dockerfile
+++ b/docker/preview/Dockerfile
@@ -1,0 +1,46 @@
+# Full-stack preview image build (shared builder). Targets: preview-backend, preview-frontend
+# Build: docker compose -f docker-compose.preview.yml build
+
+FROM node:20-bookworm AS builder
+
+WORKDIR /workspace
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# SPA talks to /api on the same origin (nginx proxies to backend)
+ENV RUNTIME_USE_SAME_ORIGIN_FOR_API=true
+ENV E2E_AUTH_ENABLED=true
+RUN node scripts/write-runtime-config.js http://127.0.0.1:3000
+
+RUN npx nx run backend:build:development --skip-nx-cache
+RUN npx nx run frontend:build:development --skip-nx-cache
+
+# --- Backend: LocalStack + local HTTP server (Lambda-style router)
+FROM node:20-bookworm-slim AS preview-backend
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /workspace/dist/apps/backend/ ./
+RUN npm ci --omit=dev
+COPY --from=builder /workspace/scripts ./scripts
+COPY docker/preview/backend-entrypoint.sh /usr/local/bin/preview-backend-entrypoint.sh
+RUN chmod +x /usr/local/bin/preview-backend-entrypoint.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/preview-backend-entrypoint.sh"]
+
+# --- Frontend: static SPA + nginx reverse proxy to backend
+FROM nginx:1.27-alpine AS preview-frontend
+
+COPY --from=builder /workspace/dist/apps/frontend/browser /usr/share/nginx/html
+COPY docker/preview/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/docker/preview/backend-entrypoint.sh
+++ b/docker/preview/backend-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+export STAGE="${STAGE:-docker}"
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-test}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
+export AWS_ENDPOINT_URL="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+export AWS_ENDPOINT_URL_DYNAMODB="${AWS_ENDPOINT_URL_DYNAMODB:-$AWS_ENDPOINT_URL}"
+export AWS_ENDPOINT_URL_S3="${AWS_ENDPOINT_URL_S3:-$AWS_ENDPOINT_URL}"
+export AWS_ENDPOINT_URL_SECRETSMANAGER="${AWS_ENDPOINT_URL_SECRETSMANAGER:-$AWS_ENDPOINT_URL}"
+
+export E2E_AUTH_ENABLED="${E2E_AUTH_ENABLED:-true}"
+export E2E_AUTH_SECRET="${E2E_AUTH_SECRET:-e2e-docker-preview-secret}"
+export LOCAL_HTTP_SERVER=true
+export BACKEND_LISTEN_HOST="${BACKEND_LISTEN_HOST:-0.0.0.0}"
+export BACKEND_PORT="${BACKEND_PORT:-3000}"
+
+LS_URL="${AWS_ENDPOINT_URL}"
+echo "[preview-backend] Waiting for LocalStack at ${LS_URL}..."
+i=0
+while [ "$i" -lt 60 ]; do
+  if curl -fsS "${LS_URL}/_localstack/health" > /dev/null 2>&1; then
+    break
+  fi
+  i=$((i + 1))
+  sleep 2
+done
+
+if ! curl -fsS "${LS_URL}/_localstack/health" > /dev/null 2>&1; then
+  echo "[preview-backend] LocalStack did not become ready in time" >&2
+  exit 1
+fi
+
+echo "[preview-backend] Provisioning DynamoDB, S3, secrets, seed data..."
+node scripts/setup-local-e2e.js
+
+echo "[preview-backend] Starting HTTP API on ${BACKEND_LISTEN_HOST}:${BACKEND_PORT}"
+exec node main.js

--- a/docker/preview/nginx.conf
+++ b/docker/preview/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
+
+    location /api/ {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=300";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docs/docker-preview.md
+++ b/docs/docker-preview.md
@@ -1,0 +1,54 @@
+# Docker full-stack preview (LocalStack)
+
+Run the **Angular app + local HTTP backend + LocalStack** (DynamoDB, S3, Secrets Manager) in Docker — no AWS account required. The UI is served on **port 4280**; the browser calls **`/api/...`** on the same origin and nginx proxies to the backend.
+
+## Prerequisites
+
+- Docker with Compose v2
+- Nothing required on ports **4280** or **4566** (change the host mapping in `docker-compose.preview.yml` if needed)
+
+## Start
+
+```bash
+npm run docker:preview:up
+```
+
+Open [http://localhost:4280](http://localhost:4280).
+
+First start **builds images** (Nx build inside Docker); expect several minutes.
+
+## Stop
+
+```bash
+npm run docker:preview:down
+```
+
+Remove volumes (clean database / LocalStack data):
+
+```bash
+npm run docker:preview:reset
+```
+
+## Authentication
+
+The preview stack enables **`/api/auth/e2e-login`** (same mechanism as local E2E). Default secret in compose: **`e2e-docker-preview-secret`**.
+
+Example (mint JWT, then set `localStorage` in the browser as in `AGENTS.md`):
+
+```bash
+curl -s -X POST http://localhost:4280/api/auth/e2e-login \
+  -H 'Content-Type: application/json' \
+  -H 'x-e2e-secret: e2e-docker-preview-secret' \
+  -d '{"userId":"user-e2e-admin","orgIdToRole":{"org-e2e-main":"admin"}}'
+```
+
+Seeded users and org match [local E2E fixtures](./local-e2e.md#seeded-identities).
+
+Override the secret by setting `E2E_AUTH_SECRET` for the `backend` service in `docker-compose.preview.yml` (keep frontend/runtime in sync only if you add a custom login path; e2e-login uses the backend env).
+
+## Implementation notes
+
+- **Backend** listens on `0.0.0.0` via `BACKEND_LISTEN_HOST` (set in the image entrypoint).
+- **Runtime config** uses `useSameOriginForApi: true` so `ApiService` calls `/api/...` relative to the nginx host.
+- **Stage** is `docker` → DynamoDB tables are suffixed `-docker` inside LocalStack.
+- **Images** are defined in `docker/preview/Dockerfile` (multi-stage: builder, `preview-backend`, `preview-frontend`).

--- a/docs/github-environments-setup.md
+++ b/docs/github-environments-setup.md
@@ -45,13 +45,11 @@ Navigate to **Settings** → **Environments** → **development** → **Environm
 - `API_GATEWAY_REGIONAL_CERTIFICATE_ARN`: ACM cert in the API region for `dev-api.*` (optional; see `infra/sam/README.md`)
 - `BASE_DOMAIN`: `dev.equip-track.com` (if using custom domains)
 
-#### PR preview (repository secret)
+#### PR preview (development environment secret)
 
-For **AWS per-PR preview** deployments (`.github/workflows/deploy-pr-preview.yml`), add a **repository** secret (not environment-specific):
+For **AWS per-PR preview** deployments (`.github/workflows/deploy-pr-preview.yml`), add **`PR_PREVIEW_SEED_PASSWORD`** under **Settings → Environments → `development` → Environment secrets** (same as `AWS_ACCESS_KEY_ID`, etc.). Single shared password for all seeded preview users (emails like `e2e.admin@example.com`); never commit this value.
 
-- **`PR_PREVIEW_SEED_PASSWORD`**: Single shared password for all seeded preview users (emails like `e2e.admin@example.com`). Required before the preview deploy job runs; never commit this value.
-
-See [pr-preview-environments.md](./pr-preview-environments.md) for full behavior and URLs.
+See [pr-preview-environments.md](./pr-preview-environments.md) for full behavior, manual validation, and URLs.
 
 #### Production Environment Secrets  
 Navigate to **Settings** → **Environments** → **production** → **Environment secrets**:

--- a/docs/local-e2e.md
+++ b/docs/local-e2e.md
@@ -11,6 +11,10 @@ This setup provisions local AWS dependencies used by backend E2E flows:
 - Docker
 - Node/npm dependencies installed (`npm ci`)
 
+## Docker full-stack preview (alternative)
+
+To run **frontend + backend + LocalStack** entirely in containers (no local `nx serve`), see [docker-preview.md](./docker-preview.md) (`npm run docker:preview:up`).
+
 ## Start and provision
 
 ```bash

--- a/docs/pr-preview-environments.md
+++ b/docs/pr-preview-environments.md
@@ -27,6 +27,10 @@ Use **Settings → Environments → `development` → Environment secrets** (sam
 
 After changing secrets, run **Actions → Deploy PR preview → Run workflow**: enter a PR number (and optional git ref). This uses the same deploy steps as pull requests.
 
+### PR comment with preview URLs
+
+The workflow posts (or updates) a bot comment on the PR with app/API links. That requires **`pull-requests: write`** on the default `GITHUB_TOKEN`. If the job deploys successfully but the comment step is skipped or warns, check **Settings → Actions → General → Workflow permissions** (“Read and write permissions”) or open the PR from a branch in the same repo (not a fork).
+
 ## URLs and login
 
 - **App:** `https://pr-<PR_NUMBER>.equip-track.com` (override with `BASE_DOMAIN` / `FRONTEND_DOMAIN` in scripts if you fork the domain layout)

--- a/docs/pr-preview-environments.md
+++ b/docs/pr-preview-environments.md
@@ -13,7 +13,7 @@ The deploy job is **skipped** until the **`PR_PREVIEW_SEED_PASSWORD`** repositor
 
 ## Required GitHub configuration
 
-In **Settings → Secrets and variables → Actions**:
+Use **Settings → Environments → `development` → Environment secrets** (same as the main dev deploy workflow). The preview workflow’s first job runs in that environment so secrets resolve correctly.
 
 | Secret | Purpose |
 |--------|---------|
@@ -21,7 +21,11 @@ In **Settings → Secrets and variables → Actions**:
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Same as development deploys (or scoped IAM for preview resources). |
 | `API_GATEWAY_REGIONAL_CERTIFICATE_ARN` | ACM cert that covers `*.equip-track.com` (or your `BASE_DOMAIN`) so `pr-<n>-api.<domain>` works. |
 
-The workflow uses GitHub **environment** `development` (same as other dev deploys).
+**Do not** rely on repository-level secrets for `PR_PREVIEW_SEED_PASSWORD` alone if the deploy job uses `environment: development`: GitHub does **not** expose environment secrets in job-level `if` conditions, so the workflow uses a small **prerequisite job** that runs in `development` and only then gates the deploy.
+
+### Manual validation
+
+After changing secrets, run **Actions → Deploy PR preview → Run workflow**: enter a PR number (and optional git ref). This uses the same deploy steps as pull requests.
 
 ## URLs and login
 

--- a/infra/sam/template.yaml
+++ b/infra/sam/template.yaml
@@ -8,10 +8,7 @@ Parameters:
   Stage:
     Type: String
     Default: dev
-    AllowedValues:
-      - dev
-      - production
-    Description: Deployment stage (matches STAGE in deploy scripts)
+    Description: Deployment stage (matches STAGE in deploy scripts; e.g. dev, production, pr-123)
   CertificateArn:
     Type: String
     Default: ''
@@ -186,6 +183,24 @@ Resources:
         Variables:
           STAGE: !Ref Stage
           LAMBDA_HANDLER_KEY: 'e2eAuth'
+          E2E_AUTH_ENABLED: !Ref E2eAuthEnabled
+          E2E_AUTH_SECRET: !Ref E2eAuthSecret
+
+  LambdafeaturePreviewPasswordAuth:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs20.x
+      Timeout: 30
+      MemorySize: 256
+      CodeUri:
+        Bucket: !Ref LambdaCodeBucketName
+        Key: !Ref LambdaCodeS3Key
+      Role: !GetAtt EquipTrackLambdaRole.Arn
+      Environment:
+        Variables:
+          STAGE: !Ref Stage
+          LAMBDA_HANDLER_KEY: 'featurePreviewPasswordAuth'
           E2E_AUTH_ENABLED: !Ref E2eAuthEnabled
           E2E_AUTH_SECRET: !Ref E2eAuthSecret
 
@@ -544,6 +559,18 @@ Resources:
               responses:
                 default:
                   description: Default response
+          /api/auth/feature-preview-password:
+            post:
+              x-amazon-apigateway-integration:
+                type: aws_proxy
+                httpMethod: POST
+                uri:
+                  Fn::Sub:
+                    - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
+                    - LambdaArn: !GetAtt LambdafeaturePreviewPasswordAuth.Arn
+              responses:
+                default:
+                  description: Default response
           /api/auth/google:
             post:
               x-amazon-apigateway-integration:
@@ -840,6 +867,13 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref Lambdae2eAuth
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${EquipTrackApi}/*/*'
+  LambdaInvokefeaturePreviewPasswordAuth:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref LambdafeaturePreviewPasswordAuth
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${EquipTrackApi}/*/*'

--- a/libs/shared/src/api/auth.ts
+++ b/libs/shared/src/api/auth.ts
@@ -32,6 +32,19 @@ export interface E2eAuthResponse extends BasicResponse {
 }
 
 /**
+ * Email/password login for isolated preview stages only (e.g. STAGE=pr-123).
+ * Disabled in production and standard dev/prod deploys.
+ */
+export interface FeaturePreviewPasswordAuthRequest {
+  email: string;
+  password: string;
+}
+
+export interface FeaturePreviewPasswordAuthResponse extends BasicResponse {
+  jwt: string;
+}
+
+/**
  * JWT payload interface with user, organization, and role information
  */
 export interface JwtPayload {

--- a/libs/shared/src/api/endpoints.ts
+++ b/libs/shared/src/api/endpoints.ts
@@ -42,6 +42,16 @@ export const endpointMetas = {
     requestType: {} as Auth.E2eAuthRequest,
     responseType: {} as Auth.E2eAuthResponse,
   } as EndpointMeta<Auth.E2eAuthRequest, Auth.E2eAuthResponse>,
+  featurePreviewPasswordAuth: {
+    path: `/api/auth/feature-preview-password`,
+    method: 'POST',
+    allowedRoles: [], // Guarded by STAGE prefix + password hash env
+    requestType: {} as Auth.FeaturePreviewPasswordAuthRequest,
+    responseType: {} as Auth.FeaturePreviewPasswordAuthResponse,
+  } as EndpointMeta<
+    Auth.FeaturePreviewPasswordAuthRequest,
+    Auth.FeaturePreviewPasswordAuthResponse
+  >,
 
   // Admin Users
   getUsers: {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "backend:serve:e2e-local": "env STAGE=local AWS_REGION=us-east-1 AWS_ENDPOINT_URL=http://localhost:4566 AWS_ENDPOINT_URL_DYNAMODB=http://localhost:4566 AWS_ENDPOINT_URL_S3=http://localhost:4566 AWS_ENDPOINT_URL_SECRETSMANAGER=http://localhost:4566 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test E2E_AUTH_ENABLED=true E2E_AUTH_SECRET=e2e-local-secret BACKEND_PORT=3000 LOCAL_HTTP_SERVER=true bash -c \"nx run backend:build:development && node dist/apps/backend/main.js\"",
     "frontend:serve:e2e-local": "node scripts/write-runtime-config.js http://localhost:3000 && nx run frontend:serve",
     "e2e:local:test": "npm run e2e:local:prepare && npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never E2E_SKIP_LOCAL_E2E_ENSURE=true npx nx run frontend-e2e:e2e-local-core",
+    "docker:preview:build": "docker compose -f docker-compose.preview.yml build",
+    "docker:preview:up": "docker compose -f docker-compose.preview.yml up -d --build",
+    "docker:preview:down": "docker compose -f docker-compose.preview.yml down",
+    "docker:preview:reset": "docker compose -f docker-compose.preview.yml down -v",
     "e2e:deployed:test": "npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never npx nx run frontend-e2e:e2e-deployed-core",
     "precommit": "nx affected -t lint,test --uncommitted --nxBail --exclude=frontend-e2e,backend-e2e && npm run validate:translations",
     "prepare": "husky"

--- a/scripts/create-dynamodb-tables.js
+++ b/scripts/create-dynamodb-tables.js
@@ -2,6 +2,7 @@ const {
   DynamoDBClient,
   CreateTableCommand,
   DescribeTableCommand,
+  waitUntilTableExists,
 } = require('@aws-sdk/client-dynamodb');
 
 // Constants
@@ -136,6 +137,39 @@ const tableDefinitions = {
   },
 };
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * After CreateTable, the table can be ACTIVE while GSIs are still CREATING.
+ * Queries on a GSI fail until every index is ACTIVE.
+ */
+async function waitForTableAndIndexesActive(client, tableName) {
+  await waitUntilTableExists({ client, maxWaitTime: 300 }, { TableName: tableName });
+  const deadline = Date.now() + 300000;
+  while (Date.now() < deadline) {
+    const out = await client.send(new DescribeTableCommand({ TableName: tableName }));
+    const table = out.Table;
+    if (!table || table.TableStatus !== 'ACTIVE') {
+      await sleep(2000);
+      continue;
+    }
+    const gsis = table.GlobalSecondaryIndexes || [];
+    const allActive =
+      gsis.length === 0 ||
+      gsis.every((ix) => ix.IndexStatus === 'ACTIVE');
+    if (allActive) {
+      console.log(`✅ Table ${tableName} and all GSIs are ACTIVE`);
+      return;
+    }
+    await sleep(2000);
+  }
+  throw new Error(
+    `Timeout waiting for DynamoDB table ${tableName} (or its GSIs) to become ACTIVE`
+  );
+}
+
 class TableCreator {
   constructor(options = {}) {
     this.region = options.region || process.env.AWS_REGION || 'il-central-1';
@@ -181,27 +215,32 @@ class TableCreator {
 
       try {
         // Check if table exists
+        let created = false;
         try {
           await this.client.send(
             new DescribeTableCommand({ TableName: stageTableName })
           );
           console.log(`✅ Table ${stageTableName} already exists`);
-          continue;
         } catch (error) {
           // Table doesn't exist, proceed with creation
           console.log(`📝 Creating table ${stageTableName}...`);
+          const command = new CreateTableCommand({
+            TableName: stageTableName,
+            KeySchema: keySchema,
+            AttributeDefinitions: attributeDefinitions,
+            GlobalSecondaryIndexes: globalSecondaryIndexes,
+            BillingMode: billingMode,
+          });
+
+          await this.client.send(command);
+          console.log(`✅ CreateTable issued for ${stageTableName}`);
+          created = true;
         }
 
-        const command = new CreateTableCommand({
-          TableName: stageTableName,
-          KeySchema: keySchema,
-          AttributeDefinitions: attributeDefinitions,
-          GlobalSecondaryIndexes: globalSecondaryIndexes,
-          BillingMode: billingMode,
-        });
-
-        await this.client.send(command);
-        console.log(`✅ Created table ${stageTableName}`);
+        await waitForTableAndIndexesActive(this.client, stageTableName);
+        if (!created) {
+          continue;
+        }
       } catch (error) {
         console.error(`❌ Error creating table ${stageTableName}:`, error);
         throw error;

--- a/scripts/deploy-frontend-fast.js
+++ b/scripts/deploy-frontend-fast.js
@@ -6,6 +6,10 @@ const {
   loadDeploymentInfo,
   hydrateFrontendInfraFromAws
 } = require('./setup-cloudfront.js');
+const {
+  syncRuntimeConfigToS3,
+  resolveRuntimeApiUrl,
+} = require('./write-runtime-config.js');
 
 // Disable AWS CLI pager to prevent interactive prompts
 process.env.AWS_PAGER = '';
@@ -216,7 +220,17 @@ async function deployFrontendFast() {
     
     // Deploy to S3
     const deployTime = deployToS3(bucketName);
-    
+
+    const runtimeApiUrl = resolveRuntimeApiUrl(deploymentInfo);
+    if (runtimeApiUrl) {
+      try {
+        syncRuntimeConfigToS3(bucketName, runtimeApiUrl);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.warn('⚠️  Could not sync runtime-config.json to S3:', msg);
+      }
+    }
+
     // Invalidate CloudFront cache with enhanced reliability and wait for completion
     let invalidationResult = null;
     if (distributionId) {

--- a/scripts/deploy-frontend.js
+++ b/scripts/deploy-frontend.js
@@ -3,6 +3,10 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { invalidateCloudFront } = require('./setup-cloudfront.js');
+const {
+  syncRuntimeConfigToS3,
+  resolveRuntimeApiUrl,
+} = require('./write-runtime-config.js');
 
 const STAGE = process.env.STAGE || 'dev';
 const AWS_REGION = process.env.AWS_REGION || 'il-central-1';
@@ -174,14 +178,25 @@ function deployFrontend() {
   
   const bucketName = createS3Bucket();
   uploadToS3(bucketName);
-  
-  const s3WebsiteUrl = `http://${bucketName}.s3-website.${AWS_REGION}.amazonaws.com`;
-  
-  // Load existing deployment info
+
   let deploymentInfo = {};
   if (fs.existsSync('deployment-info.json')) {
     deploymentInfo = JSON.parse(fs.readFileSync('deployment-info.json', 'utf8'));
   }
+  const runtimeApiUrl = resolveRuntimeApiUrl(deploymentInfo);
+  if (runtimeApiUrl) {
+    try {
+      syncRuntimeConfigToS3(bucketName, runtimeApiUrl);
+    } catch (e) {
+      console.warn('⚠️  Could not sync runtime-config.json to S3:', e.message);
+    }
+  } else {
+    console.log(
+      '⏭️  Skipping runtime-config.json S3 sync (no API URL in deployment-info and RUNTIME_API_URL unset)'
+    );
+  }
+
+  const s3WebsiteUrl = `http://${bucketName}.s3-website.${AWS_REGION}.amazonaws.com`;
   
   // Update frontend deployment info
   deploymentInfo.frontend = deploymentInfo.frontend || {};

--- a/scripts/deploy-sam-api.js
+++ b/scripts/deploy-sam-api.js
@@ -219,6 +219,11 @@ function samBuild() {
 function samDeploy(certArn, apiHostname, lambdaCode) {
   const e2eEnabled = (process.env.E2E_AUTH_ENABLED || '').toLowerCase() === 'true' ? 'true' : 'false';
   const e2eSecret = (process.env.E2E_AUTH_SECRET || '').trim();
+  if (e2eEnabled === 'true' && !e2eSecret) {
+    throw new Error('E2E_AUTH_ENABLED=true but E2E_AUTH_SECRET is empty');
+  }
+  // SAM CLI rejects empty E2eAuthSecret= in parameter-overrides; use placeholder when E2E routes are off.
+  const e2eSecretParam = e2eEnabled === 'true' ? e2eSecret : 'disabled';
   const overrides = [
     `Stage=${STAGE}`,
     `CertificateArn=${certArn}`,
@@ -226,7 +231,7 @@ function samDeploy(certArn, apiHostname, lambdaCode) {
     `LambdaCodeBucketName=${lambdaCode.bucket}`,
     `LambdaCodeS3Key=${lambdaCode.s3Key}`,
     `E2eAuthEnabled=${e2eEnabled}`,
-    `E2eAuthSecret=${e2eSecret}`,
+    `E2eAuthSecret=${e2eSecretParam}`,
   ];
   console.log('🚀 sam deploy...');
   execFileSync(

--- a/scripts/feature-preview-password.js
+++ b/scripts/feature-preview-password.js
@@ -1,0 +1,60 @@
+/**
+ * Scrypt-based password hashing for PR preview environments only.
+ * Used by seed-e2e-data (when STAGE matches pr-<number>) and verified in the backend.
+ */
+const crypto = require('crypto');
+
+const PREFIX = 'scrypt1';
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 };
+const KEYLEN = 64;
+
+/**
+ * @param {string} password
+ * @returns {Promise<string>}
+ */
+async function hashFeaturePreviewPassword(password) {
+  const salt = crypto.randomBytes(16);
+  const hash = await crypto.promises.scrypt(
+    password,
+    salt,
+    KEYLEN,
+    SCRYPT_PARAMS
+  );
+  return `${PREFIX}.${salt.toString('base64')}.${hash.toString('base64')}`;
+}
+
+/**
+ * @param {string} password
+ * @param {string} stored
+ * @returns {Promise<boolean>}
+ */
+async function verifyFeaturePreviewPassword(password, stored) {
+  if (!stored || typeof stored !== 'string' || !stored.startsWith(`${PREFIX}.`)) {
+    return false;
+  }
+  const parts = stored.split('.');
+  if (parts.length !== 3) {
+    return false;
+  }
+  const salt = Buffer.from(parts[1], 'base64');
+  const expected = Buffer.from(parts[2], 'base64');
+  if (salt.length === 0 || expected.length === 0) {
+    return false;
+  }
+  const hash = await crypto.promises.scrypt(
+    password,
+    salt,
+    expected.length,
+    SCRYPT_PARAMS
+  );
+  try {
+    return crypto.timingSafeEqual(hash, expected);
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  hashFeaturePreviewPassword,
+  verifyFeaturePreviewPassword,
+};

--- a/scripts/feature-preview-password.js
+++ b/scripts/feature-preview-password.js
@@ -3,10 +3,13 @@
  * Used by seed-e2e-data (when STAGE matches pr-<number>) and verified in the backend.
  */
 const crypto = require('crypto');
+const { promisify } = require('util');
 
 const PREFIX = 'scrypt1';
 const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 };
 const KEYLEN = 64;
+
+const scryptAsync = promisify(crypto.scrypt);
 
 /**
  * @param {string} password
@@ -14,12 +17,7 @@ const KEYLEN = 64;
  */
 async function hashFeaturePreviewPassword(password) {
   const salt = crypto.randomBytes(16);
-  const hash = await crypto.promises.scrypt(
-    password,
-    salt,
-    KEYLEN,
-    SCRYPT_PARAMS
-  );
+  const hash = await scryptAsync(password, salt, KEYLEN, SCRYPT_PARAMS);
   return `${PREFIX}.${salt.toString('base64')}.${hash.toString('base64')}`;
 }
 
@@ -41,12 +39,7 @@ async function verifyFeaturePreviewPassword(password, stored) {
   if (salt.length === 0 || expected.length === 0) {
     return false;
   }
-  const hash = await crypto.promises.scrypt(
-    password,
-    salt,
-    expected.length,
-    SCRYPT_PARAMS
-  );
+  const hash = await scryptAsync(password, salt, expected.length, SCRYPT_PARAMS);
   try {
     return crypto.timingSafeEqual(hash, expected);
   } catch {

--- a/scripts/generate-sam-template.js
+++ b/scripts/generate-sam-template.js
@@ -200,10 +200,7 @@ Parameters:
   Stage:
     Type: String
     Default: dev
-    AllowedValues:
-      - dev
-      - production
-    Description: Deployment stage (matches STAGE in deploy scripts)
+    Description: Deployment stage (matches STAGE in deploy scripts; e.g. dev, production, pr-123)
   CertificateArn:
     Type: String
     Default: ''

--- a/scripts/pr-preview-teardown.js
+++ b/scripts/pr-preview-teardown.js
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Tear down AWS resources for a PR preview stage (STAGE=pr-<number>).
+ * Deletes: API SAM stack, frontend S3 bucket, lambda code bucket, DynamoDB tables, Route53 preview hostname.
+ *
+ * Env: STAGE (required, must match /^pr-\d+$/i), AWS_REGION, BASE_DOMAIN (default equip-track.com)
+ */
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+process.env.AWS_PAGER = '';
+
+const STAGE = (process.env.STAGE || '').trim();
+const AWS_REGION = process.env.AWS_REGION || 'il-central-1';
+const BASE_DOMAIN = process.env.BASE_DOMAIN || 'equip-track.com';
+
+if (!/^pr-\d+$/i.test(STAGE)) {
+  console.error(
+    '[pr-preview-teardown] STAGE must match pr-<number> (got:',
+    STAGE,
+    ')'
+  );
+  process.exit(1);
+}
+
+const STACK_NAME = `equip-track-api-stack-${STAGE}`;
+const FRONTEND_BUCKET = `equip-track-frontend-${STAGE}`;
+const LAMBDA_BUCKET = `equip-track-lambda-code-${STAGE}`;
+const TABLE_BASES = [
+  'UsersAndOrganizations',
+  'Inventory',
+  'Forms',
+  'EquipTrackReport',
+];
+const PREVIEW_HOSTNAME = `${STAGE}.${BASE_DOMAIN}`;
+
+function aws(args) {
+  execFileSync('aws', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+}
+
+function tryAws(args) {
+  try {
+    return execFileSync('aws', args, { encoding: 'utf8' });
+  } catch {
+    return null;
+  }
+}
+
+function emptyBucket(bucket) {
+  const head = tryAws(['s3api', 'head-bucket', '--bucket', bucket]);
+  if (head === null) {
+    console.log(`[pr-preview-teardown] Bucket not found (skip): ${bucket}`);
+    return;
+  }
+  console.log(`[pr-preview-teardown] Emptying s3://${bucket}`);
+  tryAws(['s3', 'rm', `s3://${bucket}/`, '--recursive']);
+  try {
+    aws(['s3api', 'delete-bucket', '--bucket', bucket]);
+    console.log(`[pr-preview-teardown] Deleted bucket ${bucket}`);
+  } catch (e) {
+    console.warn(`[pr-preview-teardown] Could not delete bucket ${bucket}:`, e.message);
+  }
+}
+
+function deleteStack() {
+  const exists = tryAws([
+    'cloudformation',
+    'describe-stacks',
+    '--stack-name',
+    STACK_NAME,
+    '--region',
+    AWS_REGION,
+    '--output',
+    'json',
+  ]);
+  if (!exists) {
+    console.log(`[pr-preview-teardown] Stack not found (skip): ${STACK_NAME}`);
+    return;
+  }
+  console.log(`[pr-preview-teardown] Deleting stack ${STACK_NAME}`);
+  aws([
+    'cloudformation',
+    'delete-stack',
+    '--stack-name',
+    STACK_NAME,
+    '--region',
+    AWS_REGION,
+  ]);
+  aws([
+    'cloudformation',
+    'wait',
+    'stack-delete-complete',
+    '--stack-name',
+    STACK_NAME,
+    '--region',
+    AWS_REGION,
+  ]);
+  console.log(`[pr-preview-teardown] Stack deleted: ${STACK_NAME}`);
+}
+
+function deleteTables() {
+  for (const base of TABLE_BASES) {
+    const name = `${base}-${STAGE}`;
+    const out = tryAws([
+      'dynamodb',
+      'describe-table',
+      '--table-name',
+      name,
+      '--region',
+      AWS_REGION,
+      '--output',
+      'json',
+    ]);
+    if (!out) {
+      console.log(`[pr-preview-teardown] DynamoDB table not found (skip): ${name}`);
+      continue;
+    }
+    console.log(`[pr-preview-teardown] Deleting DynamoDB table ${name}`);
+    aws(['dynamodb', 'delete-table', '--table-name', name, '--region', AWS_REGION]);
+    try {
+      aws([
+        'dynamodb',
+        'wait',
+        'table-not-exists',
+        '--table-name',
+        name,
+        '--region',
+        AWS_REGION,
+      ]);
+    } catch {
+      console.warn(`[pr-preview-teardown] Wait for table delete timed or failed: ${name}`);
+    }
+  }
+}
+
+function stripHostedZoneId(id) {
+  if (!id) return id;
+  return String(id).replace(/^\/hostedzone\//, '');
+}
+
+function deleteDnsRecord() {
+  const zonesOut = tryAws([
+    'route53',
+    'list-hosted-zones-by-name',
+    '--dns-name',
+    BASE_DOMAIN,
+    '--output',
+    'json',
+  ]);
+  if (!zonesOut) {
+    console.log('[pr-preview-teardown] Could not list hosted zones (skip DNS)');
+    return;
+  }
+  const zones = JSON.parse(zonesOut).HostedZones || [];
+  const hostedZone = zones.find((z) => z.Name === `${BASE_DOMAIN}.`);
+  if (!hostedZone) {
+    console.log(`[pr-preview-teardown] No hosted zone for ${BASE_DOMAIN} (skip DNS)`);
+    return;
+  }
+  const zoneId = stripHostedZoneId(hostedZone.Id);
+  const recordName = PREVIEW_HOSTNAME.endsWith('.')
+    ? PREVIEW_HOSTNAME
+    : `${PREVIEW_HOSTNAME}.`;
+  const listOut = tryAws([
+    'route53',
+    'list-resource-record-sets',
+    '--hosted-zone-id',
+    zoneId,
+    '--output',
+    'json',
+  ]);
+  if (!listOut) return;
+  const records = JSON.parse(listOut).ResourceRecordSets || [];
+  const toDelete = records.filter(
+    (r) =>
+      String(r.Name).toLowerCase() === recordName.toLowerCase() &&
+      r.Type === 'A'
+  );
+  if (toDelete.length === 0) {
+    console.log(`[pr-preview-teardown] No A record at ${recordName} (skip DNS)`);
+    return;
+  }
+  const batch = {
+    Changes: toDelete.map((ResourceRecordSet) => ({
+      Action: 'DELETE',
+      ResourceRecordSet,
+    })),
+  };
+  fs.writeFileSync('pr-preview-dns-delete.json', JSON.stringify(batch));
+  try {
+    aws([
+      'route53',
+      'change-resource-record-sets',
+      '--hosted-zone-id',
+      zoneId,
+      '--change-batch',
+      'file://pr-preview-dns-delete.json',
+    ]);
+    console.log(`[pr-preview-teardown] Removed DNS A record(s) for ${PREVIEW_HOSTNAME}`);
+  } finally {
+    fs.unlinkSync('pr-preview-dns-delete.json');
+  }
+}
+
+function main() {
+  console.log(`[pr-preview-teardown] STAGE=${STAGE} region=${AWS_REGION}`);
+  deleteStack();
+  deleteTables();
+  emptyBucket(FRONTEND_BUCKET);
+  emptyBucket(LAMBDA_BUCKET);
+  deleteDnsRecord();
+  console.log('[pr-preview-teardown] Done');
+}
+
+main();

--- a/scripts/seed-e2e-data.js
+++ b/scripts/seed-e2e-data.js
@@ -5,6 +5,7 @@ const {
   BatchWriteCommand,
   QueryCommand,
 } = require('@aws-sdk/lib-dynamodb');
+const { hashFeaturePreviewPassword } = require('./feature-preview-password');
 
 const AWS_REGION = process.env.AWS_REGION || 'us-east-1';
 const STAGE = process.env.STAGE || 'local';
@@ -149,6 +150,17 @@ const E2E_SEED_USERS = [
 
 async function putStandardE2eOrganizationUsers(docClient) {
   const organizationId = E2E_ORGANIZATION_ID;
+  const isPreviewStage = /^pr-\d+$/i.test(STAGE);
+  let featurePreviewPasswordHash = null;
+  if (isPreviewStage) {
+    const sharedPassword = (process.env.PR_PREVIEW_SEED_PASSWORD || '').trim();
+    if (!sharedPassword) {
+      throw new Error(
+        '[seed-e2e-data] PR_PREVIEW_SEED_PASSWORD is required when STAGE matches pr-<number> (shared preview login password; store in GitHub Actions secret, not in the repo)'
+      );
+    }
+    featurePreviewPasswordHash = await hashFeaturePreviewPassword(sharedPassword);
+  }
 
   const organization = {
     id: organizationId,
@@ -170,7 +182,7 @@ async function putStandardE2eOrganizationUsers(docClient) {
   });
 
   for (const user of E2E_SEED_USERS) {
-    await putItem(docClient, USERS_AND_ORGANIZATIONS_TABLE_NAME, {
+    const userRow = {
       id: user.id,
       name: user.name,
       email: user.email,
@@ -178,7 +190,11 @@ async function putStandardE2eOrganizationUsers(docClient) {
       PK: `${USER_PREFIX}${user.id}`,
       SK: METADATA_SK,
       dbItemType: 'USER',
-    });
+    };
+    if (featurePreviewPasswordHash) {
+      userRow.featurePreviewPasswordHash = featurePreviewPasswordHash;
+    }
+    await putItem(docClient, USERS_AND_ORGANIZATIONS_TABLE_NAME, userRow);
 
     await putItem(docClient, USERS_AND_ORGANIZATIONS_TABLE_NAME, {
       organizationId,

--- a/scripts/setup-cloudfront.js
+++ b/scripts/setup-cloudfront.js
@@ -4,6 +4,10 @@ const fs = require('fs');
 
 const STAGE = process.env.STAGE || 'dev';
 const AWS_REGION = process.env.AWS_REGION || 'il-central-1';
+const {
+  syncRuntimeConfigToS3,
+  resolveRuntimeApiUrl,
+} = require('./write-runtime-config.js');
 const CLOUDFRONT_PRICE_CLASS = process.env.CLOUDFRONT_PRICE_CLASS || 'PriceClass_100';
 const SKIP_CLOUDFRONT = process.env.SKIP_CLOUDFRONT === 'true';
 
@@ -591,6 +595,15 @@ function setupCloudFront() {
   deploymentInfo.frontend.cloudfrontUrl = cloudfront.cloudfrontUrl;
 
   fs.writeFileSync('deployment-info.json', JSON.stringify(deploymentInfo, null, 2));
+
+  const runtimeApiUrl = resolveRuntimeApiUrl(deploymentInfo);
+  if (runtimeApiUrl && bucketName) {
+    try {
+      syncRuntimeConfigToS3(bucketName, runtimeApiUrl);
+    } catch (e) {
+      console.warn('⚠️  Could not sync runtime-config.json to S3:', e.message);
+    }
+  }
 
   console.log('\n🎉 CloudFront setup completed!');
   console.log(`CloudFront URL: ${cloudfront.cloudfrontUrl}`);

--- a/scripts/write-runtime-config.js
+++ b/scripts/write-runtime-config.js
@@ -12,13 +12,22 @@ const runtimeConfigPath = path.join(
   'runtime-config.json'
 );
 
-const content = JSON.stringify(
-  {
-    apiUrl,
-  },
-  null,
-  2
-);
+function useSameOriginForApi() {
+  return (
+    String(process.env.RUNTIME_USE_SAME_ORIGIN_FOR_API || '').toLowerCase() ===
+    'true'
+  );
+}
+
+const payload = useSameOriginForApi()
+  ? { useSameOriginForApi: true }
+  : { apiUrl };
+
+const content = JSON.stringify(payload, null, 2);
 
 fs.writeFileSync(runtimeConfigPath, `${content}\n`, 'utf-8');
-console.log(`[write-runtime-config] runtime apiUrl set to ${apiUrl}`);
+if (useSameOriginForApi()) {
+  console.log('[write-runtime-config] useSameOriginForApi=true (API via /api on current host)');
+} else {
+  console.log(`[write-runtime-config] runtime apiUrl set to ${apiUrl}`);
+}

--- a/scripts/write-runtime-config.js
+++ b/scripts/write-runtime-config.js
@@ -1,24 +1,118 @@
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
-const apiUrl = process.argv[2] || process.env.RUNTIME_API_URL || 'http://localhost:3000';
-const runtimeConfigPath = path.join(
-  __dirname,
-  '..',
-  'apps',
-  'frontend',
-  'src',
-  'assets',
-  'runtime-config.json'
-);
+const DEFAULT_API_URL =
+  process.env.RUNTIME_API_URL || 'http://localhost:3000';
 
-const content = JSON.stringify(
-  {
-    apiUrl,
-  },
-  null,
-  2
-);
+function isFeaturePreviewLoginEnabled() {
+  return (
+    String(process.env.RUNTIME_FEATURE_PREVIEW_LOGIN || '').toLowerCase() ===
+    'true'
+  );
+}
 
-fs.writeFileSync(runtimeConfigPath, `${content}\n`, 'utf-8');
-console.log(`[write-runtime-config] runtime apiUrl set to ${apiUrl}`);
+/**
+ * @param {string} apiUrl
+ * @returns {Record<string, unknown>}
+ */
+function buildRuntimeConfigObject(apiUrl) {
+  const url = (apiUrl || DEFAULT_API_URL).trim() || DEFAULT_API_URL;
+  return {
+    apiUrl: url,
+    ...(isFeaturePreviewLoginEnabled()
+      ? { featurePreviewLoginEnabled: true }
+      : {}),
+  };
+}
+
+/**
+ * @param {string} outputPath
+ * @param {string} [apiUrl]
+ */
+function writeRuntimeConfigFile(outputPath, apiUrl) {
+  const obj = buildRuntimeConfigObject(apiUrl ?? DEFAULT_API_URL);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(obj, null, 2)}\n`, 'utf-8');
+  console.log(
+    `[write-runtime-config] wrote ${outputPath} apiUrl=${obj.apiUrl} featurePreviewLogin=${Boolean(obj.featurePreviewLoginEnabled)}`
+  );
+}
+
+/**
+ * Upload runtime-config.json to an S3 bucket (PR preview / post-deploy refresh).
+ * @param {string} bucketName
+ * @param {string} [apiUrl]
+ */
+function syncRuntimeConfigToS3(bucketName, apiUrl) {
+  const tmpDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'rtcfg-'));
+  const tmpFile = path.join(tmpDir, 'runtime-config.json');
+  writeRuntimeConfigFile(tmpFile, apiUrl);
+  try {
+    execFileSync(
+      'aws',
+      [
+        's3',
+        'cp',
+        tmpFile,
+        `s3://${bucketName}/assets/runtime-config.json`,
+        '--cache-control',
+        'no-cache,no-store,must-revalidate',
+        '--content-type',
+        'application/json',
+      ],
+      { stdio: 'inherit' }
+    );
+  } finally {
+    fs.unlinkSync(tmpFile);
+    fs.rmdirSync(tmpDir);
+  }
+}
+
+function defaultProjectRuntimeConfigPath() {
+  return path.join(
+    __dirname,
+    '..',
+    'apps',
+    'frontend',
+    'src',
+    'assets',
+    'runtime-config.json'
+  );
+}
+
+if (require.main === module) {
+  const cliApiUrl = process.argv[2] || DEFAULT_API_URL;
+  writeRuntimeConfigFile(defaultProjectRuntimeConfigPath(), cliApiUrl);
+}
+
+/**
+ * Prefer explicit RUNTIME_API_URL, then custom API HTTPS URL from deployment-info, then execute-api URL.
+ * @param {Record<string, unknown>} [deploymentInfo]
+ * @returns {string}
+ */
+function resolveRuntimeApiUrl(deploymentInfo) {
+  const fromEnv = (process.env.RUNTIME_API_URL || '').trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  const custom =
+    deploymentInfo?.backend?.apiGateway?.customApiUrl ||
+    deploymentInfo?.backend?.apiGateway?.customDomain;
+  if (typeof custom === 'string' && custom.trim()) {
+    return custom.trim().replace(/\/$/, '');
+  }
+  const apiUrl = deploymentInfo?.api?.apiUrl;
+  if (typeof apiUrl === 'string' && apiUrl.trim()) {
+    return apiUrl.trim().replace(/\/$/, '');
+  }
+  return '';
+}
+
+module.exports = {
+  buildRuntimeConfigObject,
+  writeRuntimeConfigFile,
+  syncRuntimeConfigToS3,
+  defaultProjectRuntimeConfigPath,
+  resolveRuntimeApiUrl,
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the gap for [issue #155](https://github.com/NetanelAlbert/EquipTrack/issues/155): **real AWS** per-PR full-stack previews, merged with optional **Docker + LocalStack**.

## CI fix (PR preview secrets)

If `PR_PREVIEW_SEED_PASSWORD` was added under **Environment → development**, the old workflow’s job-level `if: secrets.PR_PREVIEW_SEED_PASSWORD` **never saw it** (GitHub limitation). This branch adds:

1. **`check-preview-secrets` job** — runs in `development`, sets `has_seed_password` from the secret.
2. **`deploy-preview`** — runs only when that output is true.
3. **`workflow_dispatch`** — **Actions → Deploy PR preview → Run workflow** with PR number (+ optional ref) to validate deployment after adding secrets.

Concurrency group fixed so `workflow_dispatch` does not reference `pull_request`.

## AWS PR previews (requirements)

| Requirement | Implementation |
|-------------|----------------|
| Unique URL per PR | `https://pr-<n>.equip-track.com` + API subdomain |
| Full stack + isolated DB | `STAGE=pr-<n>`, SAM, S3, CloudFront, DNS |
| Seed + roles | `seed-e2e-data.js` + `PR_PREVIEW_SEED_PASSWORD` on **development** env |
| Redeploy on PR push | `deploy-pr-preview.yml` |
| Cleanup | `cleanup-pr-preview.yml` + `pr-preview-teardown.js` |
| Preview-only email/password | `/api/auth/feature-preview-password` + UI flag |

Docs: [docs/pr-preview-environments.md](https://github.com/NetanelAlbert/EquipTrack/blob/cursor/issue-155-aws-docker-merge-1a60/docs/pr-preview-environments.md)

## Docker (optional)

[docs/docker-preview.md](https://github.com/NetanelAlbert/EquipTrack/blob/cursor/issue-155-aws-docker-merge-1a60/docs/docker-preview.md) — `npm run docker:preview:*`

Closes #155
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-617f1716-0793-480f-ab07-7572df4b1a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-617f1716-0793-480f-ab07-7572df4b1a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

