### PR TITLE
fix(ci): honor [skip version] only on commit subject in Auto Version Bump

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -12,11 +12,31 @@ on:
       - 'apps/frontend/src/environments/environment.prod.ts'
 
 jobs:
+  # Only honor [skip version] on the commit subject (first line). Merge commits to master often
+  # include a long body listing merged commits; many of those lines contain [skip version] from
+  # prior auto-bumps on develop, which must not suppress the post-merge bump on master.
+  skip-gate:
+    name: Check skip token on subject only
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.eval.outputs.should_run }}
+    steps:
+      - id: eval
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          first_line=$(printf '%s\n' "$COMMIT_MSG" | head -n1)
+          if printf '%s' "$first_line" | grep -qiF '[skip version]'; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   version-bump:
     name: Bump Version
+    needs: skip-gate
+    if: needs.skip-gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && !contains(github.event.head_commit.message, '[skip version]') }}
 
     permissions:
       contents: write


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The **Auto Version Bump** workflow skipped after merging `develop` into `master` because `contains(github.event.head_commit.message, '[skip version]')` matched lines in the **merge commit body** (listed commits from `develop` that include `[skip version]` in their subjects).

## Change

- Add a small **`skip-gate`** job that reads only the **first line** of `github.event.head_commit.message` and sets `should_run` to `false` only when that line contains `[skip version]` (case-insensitive).
- **`version-bump`** runs only when `needs.skip-gate.outputs.should_run == 'true'`.

This keeps intentional skips (e.g. the workflow’s own bump commits with `[skip version]` in the subject) while allowing post-merge bumps on `master` when the merge subject does not include the token.

## Files

- `.github/workflows/auto-version.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf7e6a09-3aa5-440a-94ef-6d1991f5c4c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf7e6a09-3aa5-440a-94ef-6d1991f5c4c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

