### PR TITLE
chore: upgrade Lambda runtime from nodejs20.x to nodejs22.x

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -21,7 +21,7 @@ This document describes all environment variables used across the EquipTrack dep
 - `API_THROTTLE_BURST` - API Gateway burst limit
 
 ### Lambda Configuration
-- `LAMBDA_RUNTIME` - Lambda runtime version (default: 'nodejs20.x')
+- `LAMBDA_RUNTIME` - Lambda runtime version (default: 'nodejs22.x')
 - `LAMBDA_TIMEOUT` - Lambda timeout in seconds (default: 30)
 - `LAMBDA_MEMORY_SIZE` - Lambda memory allocation in MB (default: 256)
 

--- a/infra/sam/template.yaml
+++ b/infra/sam/template.yaml
@@ -103,7 +103,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -121,7 +121,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -139,7 +139,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -157,7 +157,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -175,7 +175,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -193,7 +193,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -211,7 +211,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -229,7 +229,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -247,7 +247,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -265,7 +265,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -283,7 +283,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -301,7 +301,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -319,7 +319,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -337,7 +337,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -355,7 +355,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -373,7 +373,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -391,7 +391,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -409,7 +409,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -427,7 +427,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -445,7 +445,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -463,7 +463,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -481,7 +481,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:
@@ -499,7 +499,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 30
       MemorySize: 256
       CodeUri:

--- a/scripts/deploy-lambdas.js
+++ b/scripts/deploy-lambdas.js
@@ -53,7 +53,7 @@ const LAMBDA_DEPLOY_CONCURRENCY = Math.max(
 
 // Lambda configuration
 const LAMBDA_CONFIG = {
-  runtime: 'nodejs20.x',
+  runtime: 'nodejs22.x',
   timeout: 30,
   memorySize: 256,
 };

--- a/scripts/generate-sam-template.js
+++ b/scripts/generate-sam-template.js
@@ -164,7 +164,7 @@ function emitLambdaFunctions(handlerKeys) {
         '    Type: AWS::Serverless::Function',
         '    Properties:',
         '      Handler: index.handler',
-        '      Runtime: nodejs20.x',
+        '      Runtime: nodejs22.x',
         '      Timeout: 30',
         '      MemorySize: 256',
         '      CodeUri:',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades all AWS Lambda function runtime definitions from `nodejs20.x` to `nodejs22.x`.

**Motivation:** Node.js 20.x reached End-of-Life on **April 30, 2026**. AWS sent a health event notification (account 678961763868, region il-central-1) stating that:
- Security patches to the `nodejs20.x` Lambda runtime stop on April 30, 2026
- New functions can no longer use `nodejs20.x` starting August 31, 2026
- Existing functions can no longer be updated with `nodejs20.x` starting September 30, 2026

## Changes

- `infra/sam/template.yaml` — updated all 23 Lambda function `Runtime` values from `nodejs20.x` → `nodejs22.x`
- `scripts/generate-sam-template.js` — updated the hardcoded runtime string used when generating the SAM template
- `scripts/deploy-lambdas.js` — updated the `LAMBDA_CONFIG.runtime` default value
- `ENVIRONMENT.md` — updated documented default value for `LAMBDA_RUNTIME` env var

## Testing

- ✅ `npx nx run-many --target=lint --all` — passes (0 errors)
- ✅ `npx nx run-many --target=test --all --exclude=frontend-e2e,backend-e2e` — all 4 unit tests pass
- ✅ Pre-commit hook (`lint + test affected + validate translations`) — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d032d0eb-c30a-4f1f-955f-57d60369de9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d032d0eb-c30a-4f1f-955f-57d60369de9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

