### PR TITLE
ci: skip nightly LocalStack full E2E when develop unchanged

### DIFF
--- a/.github/workflows/e2e-localstack-full-regression.yml
+++ b/.github/workflows/e2e-localstack-full-regression.yml
@@ -14,14 +14,51 @@ env:
   NX_NO_CLOUD: 'true'
 
 jobs:
+  decide:
+    name: Check for changes on develop
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_tests: ${{ steps.decide.outputs.run_tests }}
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Restore last successful run state
+        uses: actions/cache/restore@v4
+        with:
+          path: .ci/e2e-localstack-full-state
+          key: e2e-localstack-full-develop-state
+
+      - name: Decide whether to run tests
+        id: decide
+        run: bash scripts/e2e-localstack-full-should-run.sh
+
+  skip-notice:
+    name: Skipped (no changes on develop)
+    needs: decide
+    if: needs.decide.outputs.run_tests != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip full regression
+        run: |
+          echo "Skipping Playwright full regression — develop and version unchanged since the last successful run."
+
   e2e-full-regression:
     name: Full regression (LocalStack + Playwright)
+    needs: decide
+    if: needs.decide.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
     steps:
-      - name: Checkout code
+      - name: Checkout develop
         uses: actions/checkout@v6
+        with:
+          ref: develop
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -45,6 +82,17 @@ jobs:
           E2E_SKIP_LOCAL_E2E_ENSURE: 'true'
         run: |
           npx nx run frontend-e2e:e2e-local-full
+
+      - name: Save last successful develop state
+        if: success()
+        run: bash scripts/e2e-localstack-full-save-state.sh
+
+      - name: Cache last successful develop state
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: .ci/e2e-localstack-full-state
+          key: e2e-localstack-full-develop-state
 
       - name: Upload Playwright report
         if: always()

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The **E2E Deployed Core Regression** workflow can also be triggered manually (`w
 
 ### Nightly full regression
 
-The **E2E LocalStack Full Regression** workflow runs the complete Playwright suite against LocalStack every night at **03:00 UTC**.
+The **E2E LocalStack Full Regression** workflow is scheduled every night at **03:00 UTC**. It runs the complete Playwright suite against LocalStack only when `develop` has new commits or the package version changed since the last **successful** run; otherwise the workflow exits after a quick check. Manual runs (`workflow_dispatch`) always execute the full suite.
 
 ### Workflow summary
 

--- a/scripts/e2e-localstack-full-save-state.sh
+++ b/scripts/e2e-localstack-full-save-state.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Persist develop HEAD and package version after a successful full regression run.
+set -euo pipefail
+
+STATE_DIR=".ci/e2e-localstack-full-state"
+STATE_FILE="${STATE_DIR}/state"
+
+mkdir -p "${STATE_DIR}"
+cat > "${STATE_FILE}" <<EOF
+develop_sha=$(git rev-parse HEAD)
+version=$(node -p "require('./package.json').version")
+EOF
+
+echo "Saved full regression state: $(tr '\n' ' ' < "${STATE_FILE}")"

--- a/scripts/e2e-localstack-full-should-run.sh
+++ b/scripts/e2e-localstack-full-should-run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Decide whether the nightly LocalStack full regression should run Playwright tests.
+# Skips when develop HEAD and package version are unchanged since the last successful run.
+set -euo pipefail
+
+STATE_DIR=".ci/e2e-localstack-full-state"
+STATE_FILE="${STATE_DIR}/state"
+
+write_output() {
+  local run_tests="$1"
+  local reason="$2"
+  echo "${reason}"
+  echo "run_tests=${run_tests}" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+}
+
+if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
+  write_output "true" "Manual workflow_dispatch — always run full regression."
+  exit 0
+fi
+
+git fetch --quiet origin develop
+current_sha="$(git rev-parse origin/develop)"
+current_version="$(node -p "require('./package.json').version")"
+
+if [[ ! -f "${STATE_FILE}" ]]; then
+  write_output "true" "No prior successful run state — running full regression (develop @ ${current_sha}, v${current_version})."
+  exit 0
+fi
+
+# shellcheck disable=SC1090
+source "${STATE_FILE}"
+
+if [[ "${develop_sha:-}" != "${current_sha}" ]]; then
+  write_output "true" "develop advanced (${develop_sha:-none} -> ${current_sha}) — running full regression."
+  exit 0
+fi
+
+if [[ "${version:-}" != "${current_version}" ]]; then
+  write_output "true" "Version changed (${version:-none} -> ${current_version}) — running full regression."
+  exit 0
+fi
+
+write_output "false" "No changes on develop since last successful full regression (${current_sha}, v${current_version})."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The scheduled **E2E LocalStack Full Regression** workflow now runs the expensive Playwright full suite only when something changed on `develop` since the last **successful** run:

- new commits on `develop`, or
- a new package version (from auto-version bumps)

Otherwise it completes after a short `decide` job and a visible **Skipped (no changes on develop)** job.

Manual `workflow_dispatch` runs are unchanged and always execute the full suite.

## Implementation

- **`decide` job**: checks out `develop`, restores cached state (`develop_sha` + `version`), and runs `scripts/e2e-localstack-full-should-run.sh`.
- **`e2e-full-regression` job**: runs only when `run_tests=true`; on success, saves state via `scripts/e2e-localstack-full-save-state.sh` and updates the Actions cache.
- Failed runs do not update the cache, so the next nightly still runs if the same commit never passed.

## Docs

Updated the README nightly full regression section to describe the skip behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45cc052f-851b-40b5-9569-b29132c75dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45cc052f-851b-40b5-9569-b29132c75dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

