### PR TITLE
fix(auth): call google.accounts.id.initialize() only once per page load

### DIFF
--- a/apps/frontend/src/ui/auth/google-sign-in.component.spec.ts
+++ b/apps/frontend/src/ui/auth/google-sign-in.component.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateModule } from '@ngx-translate/core';
-import { GoogleSignInComponent } from './google-sign-in.component';
+import { GoogleSignInComponent, resetGoogleSignInStateForTesting } from './google-sign-in.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('GoogleSignInComponent', () => {
@@ -25,6 +25,7 @@ describe('GoogleSignInComponent', () => {
   };
 
   beforeEach(async () => {
+    resetGoogleSignInStateForTesting();
     mockSnackBar = jest.fn();
 
     mockGoogleApi = {
@@ -156,6 +157,7 @@ describe('GoogleSignInComponent', () => {
       );
       jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
+      resetGoogleSignInStateForTesting();
       mockGoogleApi.accounts.id.initialize.mockImplementationOnce(() => {
         throw new Error('Test error');
       });

--- a/apps/frontend/src/ui/auth/google-sign-in.component.ts
+++ b/apps/frontend/src/ui/auth/google-sign-in.component.ts
@@ -3,6 +3,7 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
+  OnDestroy,
   inject,
   output,
   input,
@@ -24,6 +25,15 @@ interface GoogleCredentialResponse {
   select_by: string; // How the user signed in
 }
 
+let googleSignInInitialized = false;
+let activeCredentialHandler: ((r: GoogleCredentialResponse) => void) | null = null;
+
+/** Resets module-level GIS state. Call only from tests. */
+export function resetGoogleSignInStateForTesting(): void {
+  googleSignInInitialized = false;
+  activeCredentialHandler = null;
+}
+
 @Component({
   selector: 'app-google-sign-in',
   standalone: true,
@@ -36,7 +46,7 @@ interface GoogleCredentialResponse {
   templateUrl: './google-sign-in.component.html',
   styleUrl: './google-sign-in.component.scss',
 })
-export class GoogleSignInComponent implements AfterViewInit {
+export class GoogleSignInComponent implements AfterViewInit, OnDestroy {
   @ViewChild('googleButtonContainer', { static: true })
   googleButtonContainer!: ElementRef<HTMLElement>;
 
@@ -96,19 +106,20 @@ export class GoogleSignInComponent implements AfterViewInit {
         throw new Error('Google library not loaded');
       }
 
-      // Initialize Google Identity Services with COOP-compatible settings
-      window.google.accounts.id.initialize({
-        client_id: environment.googleClientId,
-        callback: (response: GoogleCredentialResponse) => {
-          this.handleCredentialResponse(response);
-        },
-        auto_select: false,
-        cancel_on_tap_outside: true,
-        context: 'signin',
-        // Add COOP-compatible settings
-        use_fedcm_for_prompt: false,
-        itp_support: false,
-      });
+      activeCredentialHandler = (response) => this.handleCredentialResponse(response);
+
+      if (!googleSignInInitialized) {
+        googleSignInInitialized = true;
+        window.google.accounts.id.initialize({
+          client_id: environment.googleClientId,
+          callback: (response: GoogleCredentialResponse) => activeCredentialHandler?.(response),
+          auto_select: false,
+          cancel_on_tap_outside: true,
+          context: 'signin',
+          use_fedcm_for_prompt: false,
+          itp_support: false,
+        });
+      }
 
       // Render the Google Sign-In button
       window.google.accounts.id.renderButton(
@@ -196,5 +207,9 @@ export class GoogleSignInComponent implements AfterViewInit {
    */
   private showSuccess(message: string): void {
     this.notificationService.showSuccess('auth.success', message);
+  }
+
+  ngOnDestroy(): void {
+    activeCredentialHandler = null;
   }
 }

--- a/apps/frontend/src/ui/auth/google-sign-in.component.ts
+++ b/apps/frontend/src/ui/auth/google-sign-in.component.ts
@@ -25,13 +25,34 @@ interface GoogleCredentialResponse {
   select_by: string; // How the user signed in
 }
 
-let googleSignInInitialized = false;
-let activeCredentialHandler: ((r: GoogleCredentialResponse) => void) | null = null;
+/** Symbol used as a key on `window` so the flag survives HMR module re-evaluation. */
+const GIS_INIT_FLAG = '__et_gis_initialized__';
 
-/** Resets module-level GIS state. Call only from tests. */
+type WindowWithGis = Window & {
+  [GIS_INIT_FLAG]?: boolean;
+  __et_gis_handler__?: ((r: GoogleCredentialResponse) => void) | null;
+};
+
+function isGisInitialized(): boolean {
+  return !!(window as WindowWithGis)[GIS_INIT_FLAG];
+}
+
+function markGisInitialized(): void {
+  (window as WindowWithGis)[GIS_INIT_FLAG] = true;
+}
+
+function getActiveHandler(): ((r: GoogleCredentialResponse) => void) | null | undefined {
+  return (window as WindowWithGis).__et_gis_handler__;
+}
+
+function setActiveHandler(fn: ((r: GoogleCredentialResponse) => void) | null): void {
+  (window as WindowWithGis).__et_gis_handler__ = fn;
+}
+
+/** Resets window-level GIS state. Call only from tests. */
 export function resetGoogleSignInStateForTesting(): void {
-  googleSignInInitialized = false;
-  activeCredentialHandler = null;
+  (window as WindowWithGis)[GIS_INIT_FLAG] = false;
+  (window as WindowWithGis).__et_gis_handler__ = null;
 }
 
 @Component({
@@ -106,13 +127,13 @@ export class GoogleSignInComponent implements AfterViewInit, OnDestroy {
         throw new Error('Google library not loaded');
       }
 
-      activeCredentialHandler = (response) => this.handleCredentialResponse(response);
+      setActiveHandler((response) => this.handleCredentialResponse(response));
 
-      if (!googleSignInInitialized) {
-        googleSignInInitialized = true;
+      if (!isGisInitialized()) {
+        markGisInitialized();
         window.google.accounts.id.initialize({
           client_id: environment.googleClientId,
-          callback: (response: GoogleCredentialResponse) => activeCredentialHandler?.(response),
+          callback: (response: GoogleCredentialResponse) => getActiveHandler()?.(response),
           auto_select: false,
           cancel_on_tap_outside: true,
           context: 'signin',
@@ -210,6 +231,6 @@ export class GoogleSignInComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    activeCredentialHandler = null;
+    setActiveHandler(null);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a user signs out, Angular navigates to `/login`, which destroys and re-creates `LoginComponent` and its child `GoogleSignInComponent`. Each mount triggered `ngAfterViewInit → initializeGoogleSignIn → setupGoogleSignIn → window.google.accounts.id.initialize()`.

The Google Identity Services (GIS) library only supports `initialize()` **once per page load** and logs a warning on every subsequent call. It also caused the `Cross-Origin-Opener-Policy policy would block the window.postMessage call` error.

## Fix

Two module-level (file-scope) variables are added outside the class:

```ts
let googleSignInInitialized = false;
let activeCredentialHandler: ((r: GoogleCredentialResponse) => void) | null = null;
```

In `setupGoogleSignIn`:
- `activeCredentialHandler` is always updated to point to the current component instance.
- `window.google.accounts.id.initialize()` is only called the **first time** (`googleSignInInitialized` guard).
- `renderButton()` is still called every time — that's fine and intentional.

`ngOnDestroy` nulls `activeCredentialHandler` so a destroyed instance can't receive stale GIS callbacks.

A `resetGoogleSignInStateForTesting()` export is added to allow unit tests to reset module-level state between test cases.

## Result

- `initialize()` is called **exactly once** for the entire page lifetime.
- The correct live component instance always handles GIS callbacks via the `activeCredentialHandler` indirection.
- A destroyed instance cannot receive stale responses.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-818d4477-f72b-4f80-8186-8eb4aa84ed97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-818d4477-f72b-4f80-8186-8eb4aa84ed97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

