### PR TITLE
lint: forbid unused variables, functions, and imports

### DIFF
--- a/apps/backend/src/db/tables/users-and-organizations.adapter.ts
+++ b/apps/backend/src/db/tables/users-and-organizations.adapter.ts
@@ -125,7 +125,6 @@ export class UsersAndOrganizationsAdapter {
 
   private getUser(userDB: UserDb): User {
     // Destructure to exclude database-specific fields and keep only User fields
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { PK, SK, dbItemType, googleSub, ...user } = userDB;
     return user;
   }
@@ -134,14 +133,12 @@ export class UsersAndOrganizationsAdapter {
     userInOrganizationsDB: UserInOrganizationDb
   ): UserInOrganization {
     // Destructure to exclude database-specific fields and keep only UserInOrganization fields
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { PK, SK, dbItemType, ...userInOrganization } = userInOrganizationsDB;
     return userInOrganization;
   }
 
   private getOrganization(organizationDB: OrganizationDb): Organization {
     // Destructure to exclude database-specific fields and keep only Organization fields
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { PK, SK, dbItemType, ...organization } = organizationDB;
     return organization;
   }

--- a/apps/frontend/src/app/app.init.service.ts
+++ b/apps/frontend/src/app/app.init.service.ts
@@ -3,7 +3,6 @@ import { AuthService } from '../services/auth.service';
 import { UserStore } from '../store/user.store';
 import { AuthStore } from '../store';
 import { OrganizationService } from '../services/organization.service';
-import { UserRole } from '@equip-track/shared';
 
 @Injectable({ providedIn: 'root' })
 export class AppInitService {

--- a/apps/frontend/src/store/forms.store.ts
+++ b/apps/frontend/src/store/forms.store.ts
@@ -475,7 +475,6 @@ export const FormsStore = signalStore(
           return presignedUrls[form.formID].url;
         }
         console.log('presignedUrls', presignedUrls);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { [form.formID]: _expired, ...remainingUrls } = presignedUrls;
 
         updateState({

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,8 +26,38 @@ module.exports = [
     },
   },
   {
-    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
-    // Override or add rules here
-    rules: {},
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          vars: 'all',
+          args: 'after-used',
+          ignoreRestSiblings: true,
+          caughtErrors: 'all',
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {
+      'no-unused-vars': [
+        'error',
+        {
+          vars: 'all',
+          args: 'after-used',
+          ignoreRestSiblings: true,
+          caughtErrors: 'all',
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds ESLint rules to prevent unused code — variables, constants, functions, and imports — across the entire monorepo.

### Changes

**`eslint.config.js`** (root config, inherited by all projects):
- Adds `@typescript-eslint/no-unused-vars` as `error` for all `.ts`/`.tsx` files
- Adds `no-unused-vars` as `error` for all `.js`/`.jsx` files
- Config: `vars: 'all'`, `args: 'after-used'`, `ignoreRestSiblings: true`, `caughtErrors: 'all'`
- Variables prefixed with `_` are exempt (via `varsIgnorePattern`, `argsIgnorePattern`, `caughtErrorsIgnorePattern`)
- Disables the base `no-unused-vars` for TS files to avoid duplicate reports

### Fixes for violations raised by the new rule

| File | Fix |
|---|---|
| `apps/frontend/src/app/app.init.service.ts` | Removed unused `UserRole` import |
| `apps/backend/src/db/tables/users-and-organizations.adapter.ts` | Removed 3 stale `eslint-disable-next-line` comments (now redundant because `ignoreRestSiblings: true` silences destructured siblings of a rest spread) |
| `apps/frontend/src/store/forms.store.ts` | Removed 1 stale `eslint-disable-next-line` comment (`_expired` already matches the `^_` ignore pattern) |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5302d429-41b2-4282-94c4-79ac9e4ccb5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5302d429-41b2-4282-94c4-79ac9e4ccb5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

