### PR TITLE
feat: local preview compose stack with seeded email/password login

### DIFF
--- a/.env.preview.example
+++ b/.env.preview.example
@@ -1,0 +1,4 @@
+# Copy to .env.preview and fill in your chosen password.
+# This file MUST NOT be committed with real secrets.
+PREVIEW_SEED_PASSWORD=replace-with-your-secret
+E2E_AUTH_SECRET=e2e-local-secret

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ See `apps/frontend-e2e/src/helpers/e2e-auth.ts` for the canonical Playwright imp
 - **Unit tests**: `npx nx run-many --target=test --all --exclude=frontend-e2e`
 - **E2E tests**: `npm run e2e:local:test` (provisions LocalStack, installs Chromium, runs Playwright core regression). Chromium + system deps are pre-installed by the update script; to run the core regression alone: `E2E_SKIP_LOCAL_E2E_ENSURE=true PLAYWRIGHT_HTML_OPEN=never npx nx run frontend-e2e:e2e-local-core`.
 - **Pre-commit hook** runs `npm run precommit` (lint + test affected + validate translations).
+- **Self-contained preview stack** (LocalStack + backend + nginx, with seeded email/password login): `npm run preview:compose:up` → open `http://127.0.0.1:8080`. See [`docs/local-preview.md`](docs/local-preview.md) for credentials and troubleshooting.
 
 ### Gotchas
 

--- a/apps/backend/src/api/auth/feature-preview-password.spec.ts
+++ b/apps/backend/src/api/auth/feature-preview-password.spec.ts
@@ -1,0 +1,61 @@
+import { UserRole, UserState } from '@equip-track/shared';
+import { handler } from './feature-preview-password';
+import { UsersAndOrganizationsAdapter } from '../../db/tables/users-and-organizations.adapter';
+import { JwtService } from '../../services/jwt.service';
+import { hashPreviewPasswordForTests } from './preview-password-crypto';
+
+describe('feature-preview-password handler', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.FEATURE_PREVIEW_AUTH_ENABLED = 'true';
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 403 when feature preview auth is disabled', async () => {
+    process.env.FEATURE_PREVIEW_AUTH_ENABLED = 'false';
+
+    await expect(
+      handler({ email: 'a@b.com', password: 'x' }, {})
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('returns jwt when credentials match', async () => {
+    const hash = hashPreviewPasswordForTests('secret');
+    jest
+      .spyOn(
+        UsersAndOrganizationsAdapter.prototype,
+        'getUserByEmailForFeaturePreview'
+      )
+      .mockResolvedValue({
+        user: {
+          id: 'user-1',
+          email: 'e@x.com',
+          name: 'T',
+          state: UserState.Active,
+        },
+        userInOrganizations: [
+          {
+            organizationId: 'org-1',
+            role: UserRole.Admin,
+            userId: 'user-1',
+          },
+        ],
+        featurePreviewPasswordHash: hash,
+      });
+
+    jest
+      .spyOn(JwtService.prototype, 'generateToken')
+      .mockResolvedValue('jwt-token');
+
+    const res = await handler({ email: 'e@x.com', password: 'secret' }, {});
+
+    expect(res.status).toBe(true);
+    expect(res.jwt).toBe('jwt-token');
+  });
+});

--- a/apps/backend/src/api/auth/feature-preview-password.ts
+++ b/apps/backend/src/api/auth/feature-preview-password.ts
@@ -1,0 +1,69 @@
+import { Auth, UserRole } from '@equip-track/shared';
+import { APIGatewayProxyEventPathParameters } from 'aws-lambda';
+import { UsersAndOrganizationsAdapter } from '../../db/tables/users-and-organizations.adapter';
+import { JwtService } from '../../services/jwt.service';
+import {
+  badRequest,
+  forbidden,
+  internalServerError,
+  isErrorResponse,
+  unauthorized,
+} from '../responses';
+import { verifyPreviewPassword } from './preview-password-crypto';
+
+function buildOrgIdToRole(
+  userInOrganizations: Array<{ organizationId: string; role: UserRole }>
+): Record<string, UserRole> {
+  return userInOrganizations.reduce<Record<string, UserRole>>((acc, row) => {
+    acc[row.organizationId] = row.role;
+    return acc;
+  }, {});
+}
+
+export const handler = async (
+  req: Auth.FeaturePreviewPasswordRequest,
+  _pathParams: APIGatewayProxyEventPathParameters
+): Promise<Auth.FeaturePreviewPasswordResponse> => {
+  try {
+    if (process.env.FEATURE_PREVIEW_AUTH_ENABLED !== 'true') {
+      throw forbidden('Feature preview authentication is disabled');
+    }
+
+    const email = typeof req?.email === 'string' ? req.email.trim() : '';
+    const password = typeof req?.password === 'string' ? req.password : '';
+
+    if (!email || !password) {
+      throw badRequest('Email and password are required');
+    }
+
+    const adapter = new UsersAndOrganizationsAdapter();
+    const row = await adapter.getUserByEmailForFeaturePreview(email);
+
+    if (!row || !row.featurePreviewPasswordHash) {
+      throw unauthorized('Invalid email or password');
+    }
+
+    if (!verifyPreviewPassword(password, row.featurePreviewPasswordHash)) {
+      throw unauthorized('Invalid email or password');
+    }
+
+    const orgIdToRole = buildOrgIdToRole(row.userInOrganizations);
+    if (Object.keys(orgIdToRole).length === 0) {
+      throw unauthorized('Invalid email or password');
+    }
+
+    const jwtService = new JwtService();
+    const jwt = await jwtService.generateToken(row.user.id, orgIdToRole);
+
+    return {
+      status: true,
+      jwt,
+    };
+  } catch (error) {
+    if (isErrorResponse(error)) {
+      throw error;
+    }
+
+    throw internalServerError('Authentication failed');
+  }
+};

--- a/apps/backend/src/api/auth/preview-password-crypto.spec.ts
+++ b/apps/backend/src/api/auth/preview-password-crypto.spec.ts
@@ -1,0 +1,18 @@
+import {
+  hashPreviewPasswordForTests,
+  verifyPreviewPassword,
+} from './preview-password-crypto';
+
+describe('preview-password-crypto', () => {
+  it('verifies a hash produced by hashPreviewPasswordForTests', () => {
+    const plain = 'test-secret-password';
+    const stored = hashPreviewPasswordForTests(plain);
+    expect(verifyPreviewPassword(plain, stored)).toBe(true);
+    expect(verifyPreviewPassword('wrong', stored)).toBe(false);
+  });
+
+  it('rejects invalid stored format', () => {
+    expect(verifyPreviewPassword('x', undefined)).toBe(false);
+    expect(verifyPreviewPassword('x', 'bad')).toBe(false);
+  });
+});

--- a/apps/backend/src/api/auth/preview-password-crypto.ts
+++ b/apps/backend/src/api/auth/preview-password-crypto.ts
@@ -1,0 +1,39 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'crypto';
+
+const PREFIX = 'scrypt1';
+
+/**
+ * Verifies a password against a value produced by {@link hashPreviewPassword} in scripts/lib/preview-password-hash.js.
+ */
+export function verifyPreviewPassword(
+  plain: string,
+  stored: string | undefined
+): boolean {
+  if (!stored || typeof stored !== 'string') {
+    return false;
+  }
+  const parts = stored.split(':');
+  if (parts.length !== 3 || parts[0] !== PREFIX) {
+    return false;
+  }
+  try {
+    const salt = new Uint8Array(Buffer.from(parts[1], 'base64'));
+    const expected = new Uint8Array(Buffer.from(parts[2], 'base64'));
+    const derived = scryptSync(plain, salt, 64);
+    const derivedU8 = new Uint8Array(derived);
+    if (derivedU8.length !== expected.length) {
+      return false;
+    }
+    return timingSafeEqual(derivedU8, expected);
+  } catch {
+    return false;
+  }
+}
+
+/** Dev-only helper for tests; production uses Node script hashing in seed. */
+export function hashPreviewPasswordForTests(plain: string): string {
+  const salt = randomBytes(16);
+  const saltU8 = new Uint8Array(salt);
+  const derived = scryptSync(plain, saltU8, 64);
+  return `${PREFIX}:${Buffer.from(saltU8).toString('base64')}:${Buffer.from(new Uint8Array(derived)).toString('base64')}`;
+}

--- a/apps/backend/src/api/handlers.ts
+++ b/apps/backend/src/api/handlers.ts
@@ -1,6 +1,7 @@
 import { endpointMetas, EndpointMeta, JwtPayload } from '@equip-track/shared';
 import { handler as googleAuthHandler } from './auth/google';
 import { handler as e2eAuthHandler } from './auth/e2e-login';
+import { handler as featurePreviewPasswordAuthHandler } from './auth/feature-preview-password';
 import { handler as getUsersHandler } from './admin/users/get';
 import { handler as setUserHandler } from './admin/users/set';
 import { handler as inviteUserHandler } from './admin/users/invite';
@@ -49,6 +50,7 @@ export const handlers: HandlersDefinition = {
   // Authentication
   googleAuth: googleAuthHandler,
   e2eAuth: e2eAuthHandler,
+  featurePreviewPasswordAuth: featurePreviewPasswordAuthHandler,
 
   // Admin Users
   getUsers: getUsersHandler,

--- a/apps/backend/src/db/models.ts
+++ b/apps/backend/src/db/models.ts
@@ -49,6 +49,8 @@ export interface ProductDb extends DbItem {
 export interface UserDb extends User, DbItem {
   // Optional Google sub ID for users who authenticated with Google
   googleSub?: string;
+  /** Scrypt hash for preview-only password login (never returned to clients). */
+  featurePreviewPasswordHash?: string;
 }
 
 /**

--- a/apps/backend/src/db/tables/users-and-organizations.adapter.ts
+++ b/apps/backend/src/db/tables/users-and-organizations.adapter.ts
@@ -125,7 +125,14 @@ export class UsersAndOrganizationsAdapter {
 
   private getUser(userDB: UserDb): User {
     // Destructure to exclude database-specific fields and keep only User fields
-    const { PK, SK, dbItemType, googleSub, ...user } = userDB;
+    const {
+      PK: _PK,
+      SK: _SK,
+      dbItemType: _dbItemType,
+      googleSub: _googleSub,
+      featurePreviewPasswordHash: _featurePreviewPasswordHash,
+      ...user
+    } = userDB;
     return user;
   }
 
@@ -133,13 +140,13 @@ export class UsersAndOrganizationsAdapter {
     userInOrganizationsDB: UserInOrganizationDb
   ): UserInOrganization {
     // Destructure to exclude database-specific fields and keep only UserInOrganization fields
-    const { PK, SK, dbItemType, ...userInOrganization } = userInOrganizationsDB;
+    const { PK: _PK, SK: _SK, dbItemType: _dbItemType, ...userInOrganization } = userInOrganizationsDB;
     return userInOrganization;
   }
 
   private getOrganization(organizationDB: OrganizationDb): Organization {
     // Destructure to exclude database-specific fields and keep only Organization fields
-    const { PK, SK, dbItemType, ...organization } = organizationDB;
+    const { PK: _PK, SK: _SK, dbItemType: _dbItemType, ...organization } = organizationDB;
     return organization;
   }
 
@@ -419,6 +426,58 @@ export class UsersAndOrganizationsAdapter {
     });
 
     await this.docClient.send(command);
+  }
+
+  /**
+   * Same as {@link getUserByEmail} but exposes the preview password hash for auth (not part of {@link User}).
+   */
+  async getUserByEmailForFeaturePreview(
+    email: string
+  ): Promise<
+    | {
+        user: User;
+        userInOrganizations: UserInOrganization[];
+        featurePreviewPasswordHash: string | undefined;
+      }
+    | undefined
+  > {
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const userQuery = new QueryCommand({
+      TableName: this.tableName,
+      IndexName: 'UsersByEmailIndex',
+      KeyConditionExpression: 'email = :email AND SK = :sk',
+      ExpressionAttributeValues: {
+        ':email': normalizedEmail,
+        ':sk': METADATA_SK,
+      },
+    });
+
+    const userResult = await this.docClient.send(userQuery);
+    const userItems = userResult.Items as UserDb[];
+
+    if (!userItems || userItems.length === 0) {
+      return undefined;
+    }
+
+    const userDb = userItems[0];
+    const featurePreviewPasswordHash = userDb.featurePreviewPasswordHash;
+    const user = this.getUser(userDb);
+
+    const orgQuery = new QueryCommand({
+      TableName: this.tableName,
+      KeyConditionExpression: 'PK = :pk AND begins_with(SK, :orgPrefix)',
+      ExpressionAttributeValues: {
+        ':pk': userDb.PK,
+        ':orgPrefix': ORG_PREFIX,
+      },
+    });
+
+    const orgResult = await this.docClient.send(orgQuery);
+    const orgItems = (orgResult.Items as UserInOrganizationDb[]) ?? [];
+    const userInOrganizations = orgItems.map(this.getUserInOrganizations);
+
+    return { user, userInOrganizations, featurePreviewPasswordHash };
   }
 
   /**

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -28,7 +28,15 @@
     "try-again": "Try Again",
     "try-again-detailed": "Try signing in again",
     "error": "Authentication Error",
-    "success": "Authentication Successful"
+    "success": "Authentication Successful",
+    "feature-preview-intro": "Preview environment: sign in with the shared credentials provided by your team.",
+    "feature-preview-email": "Email",
+    "feature-preview-password": "Password",
+    "feature-preview-submit": "Sign in",
+    "feature-preview-email-required": "Email is required",
+    "feature-preview-email-invalid": "Enter a valid email address",
+    "feature-preview-password-required": "Password is required",
+    "feature-preview-form-aria": "Preview sign-in with email and password"
   },
   "common": {
     "close": "Close",

--- a/apps/frontend/src/assets/i18n/he.json
+++ b/apps/frontend/src/assets/i18n/he.json
@@ -28,7 +28,15 @@
     "try-again": "נסה שוב",
     "try-again-detailed": "נסה להתחבר שוב",
     "error": "שגיאת אימות",
-    "success": "האימות הצליח"
+    "success": "האימות הצליח",
+    "feature-preview-intro": "סביבת תצוגה מקדימה: התחבר/י עם פרטי הגישה המשותפים שסופקו על ידי הצוות.",
+    "feature-preview-email": "אימייל",
+    "feature-preview-password": "סיסמה",
+    "feature-preview-submit": "התחברות",
+    "feature-preview-email-required": "נדרש אימייל",
+    "feature-preview-email-invalid": "הזן/י כתובת אימייל תקינה",
+    "feature-preview-password-required": "נדרשת סיסמה",
+    "feature-preview-form-aria": "התחברות לתצוגה מקדימה באימייל וסיסמה"
   },
   "common": {
     "close": "סגור",

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -2,7 +2,12 @@ import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { GoogleAuthRequest, GoogleAuthResponse } from '@equip-track/shared';
+import {
+  GoogleAuthRequest,
+  GoogleAuthResponse,
+  FeaturePreviewPasswordRequest,
+  FeaturePreviewPasswordResponse,
+} from '@equip-track/shared';
 import { ApiService } from './api.service';
 import { AuthStore } from '../store/auth.store';
 import { UserStore } from '../store/user.store';
@@ -39,6 +44,50 @@ export class AuthService {
       console.error('Auth initialization failed:', error);
       return false;
     }
+  }
+
+  authenticateWithFeaturePreviewPassword(
+    email: string,
+    password: string
+  ): Observable<FeaturePreviewPasswordResponse> {
+    this.authStore.setAuthLoading();
+
+    const request: FeaturePreviewPasswordRequest = { email, password };
+
+    return this.apiService.endpoints.featurePreviewPasswordAuth
+      .execute(request, {}, false)
+      .pipe(
+        map((response) => {
+          if (response.status && response.jwt) {
+            this.storeToken(response.jwt);
+            this.authStore.setToken(response.jwt);
+            this.validateAndCacheToken(response.jwt);
+            this.authStore.setAuthSuccess();
+          } else {
+            this.authStore.setAuthError('Invalid authentication response');
+          }
+          return response;
+        }),
+        catchError((error) => {
+          console.error('Feature preview authentication failed:', error);
+
+          let errorMessage = 'Authentication failed';
+          if (error.status === 0) {
+            errorMessage = 'Network error. Please check your connection.';
+          } else if (error.status >= 500) {
+            errorMessage = 'Server error. Please try again later.';
+          } else if (error.status === 401 || error.status === 403) {
+            errorMessage =
+              'Authentication failed. Please verify your email and password.';
+          } else if (error.message) {
+            errorMessage = error.message;
+          }
+
+          this.authStore.setAuthError(errorMessage);
+          this.clearAuthenticationState();
+          throw error;
+        })
+      );
   }
 
   // Enhanced Google authentication with comprehensive error handling

--- a/apps/frontend/src/services/runtime-config.service.ts
+++ b/apps/frontend/src/services/runtime-config.service.ts
@@ -3,6 +3,8 @@ import { environment } from '../environments/environment';
 
 interface RuntimeConfig {
   apiUrl?: string;
+  /** When true, login shows email/password for preview environments (runtime file only). */
+  featurePreviewLoginEnabled?: boolean;
 }
 
 function isRuntimeConfig(value: unknown): value is RuntimeConfig {
@@ -56,6 +58,10 @@ export class RuntimeConfigService {
     return this.config.apiUrl || environment.apiUrl;
   }
 
+  get featurePreviewLoginEnabled(): boolean {
+    return this.config.featurePreviewLoginEnabled === true;
+  }
+
   async load(): Promise<void> {
     try {
       const response = await fetch('/assets/runtime-config.json', {
@@ -70,18 +76,38 @@ export class RuntimeConfigService {
         return;
       }
 
-      const fileApiUrl = configFromFile.apiUrl?.trim();
-      if (fileApiUrl) {
-        if (shouldIgnoreRuntimeApiUrl(fileApiUrl)) {
-          console.warn(
-            '[RuntimeConfig] Ignoring runtime-config apiUrl pointing to a local/private host while app is served from a public origin. Using build-time environment.apiUrl instead.'
-          );
-        } else {
-          this.config = {
-            ...this.config,
-            apiUrl: fileApiUrl,
-          };
+      const rawApiUrl = configFromFile.apiUrl;
+      if (typeof rawApiUrl === 'string') {
+        const fileApiUrl = rawApiUrl.trim();
+        if (fileApiUrl === 'same-origin') {
+          if (typeof globalThis !== 'undefined' && 'location' in globalThis) {
+            this.config = {
+              ...this.config,
+              apiUrl: (globalThis as unknown as Window).location.origin,
+            };
+          }
+        } else if (fileApiUrl) {
+          if (shouldIgnoreRuntimeApiUrl(fileApiUrl)) {
+            console.warn(
+              '[RuntimeConfig] Ignoring runtime-config apiUrl pointing to a local/private host while app is served from a public origin. Using build-time environment.apiUrl instead.'
+            );
+          } else {
+            this.config = {
+              ...this.config,
+              apiUrl: fileApiUrl,
+            };
+          }
         }
+      }
+
+      if (
+        typeof configFromFile.featurePreviewLoginEnabled === 'boolean' &&
+        configFromFile.featurePreviewLoginEnabled
+      ) {
+        this.config = {
+          ...this.config,
+          featurePreviewLoginEnabled: true,
+        };
       }
     } catch {
       // No-op fallback to environment config when runtime file is unavailable.

--- a/apps/frontend/src/ui/auth/feature-preview-sign-in.component.html
+++ b/apps/frontend/src/ui/auth/feature-preview-sign-in.component.html
@@ -1,0 +1,50 @@
+<form
+  class="feature-preview-form"
+  [formGroup]="form"
+  (ngSubmit)="onSubmit()"
+  data-testid="feature-preview-sign-in-form"
+  [attr.aria-label]="'auth.feature-preview-form-aria' | translate"
+>
+  <p class="feature-preview-intro">
+    {{ 'auth.feature-preview-intro' | translate }}
+  </p>
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>{{ 'auth.feature-preview-email' | translate }}</mat-label>
+    <input
+      matInput
+      type="email"
+      formControlName="email"
+      autocomplete="username"
+      data-testid="feature-preview-email"
+    />
+    @if (form.controls.email.touched && form.controls.email.hasError('required')) {
+      <mat-error>{{ 'auth.feature-preview-email-required' | translate }}</mat-error>
+    }
+    @if (form.controls.email.touched && form.controls.email.hasError('email')) {
+      <mat-error>{{ 'auth.feature-preview-email-invalid' | translate }}</mat-error>
+    }
+  </mat-form-field>
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>{{ 'auth.feature-preview-password' | translate }}</mat-label>
+    <input
+      matInput
+      type="password"
+      formControlName="password"
+      autocomplete="current-password"
+      data-testid="feature-preview-password"
+    />
+    @if (form.controls.password.touched && form.controls.password.hasError('required')) {
+      <mat-error>{{ 'auth.feature-preview-password-required' | translate }}</mat-error>
+    }
+  </mat-form-field>
+  <button
+    mat-raised-button
+    color="primary"
+    type="submit"
+    class="submit-button"
+    data-testid="feature-preview-submit"
+    [disabled]="form.invalid"
+  >
+    {{ 'auth.feature-preview-submit' | translate }}
+  </button>
+</form>

--- a/apps/frontend/src/ui/auth/feature-preview-sign-in.component.scss
+++ b/apps/frontend/src/ui/auth/feature-preview-sign-in.component.scss
@@ -1,0 +1,22 @@
+.feature-preview-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 100%;
+}
+
+.feature-preview-intro {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  opacity: 0.9;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.submit-button {
+  align-self: flex-start;
+  margin-top: 0.25rem;
+}

--- a/apps/frontend/src/ui/auth/feature-preview-sign-in.component.ts
+++ b/apps/frontend/src/ui/auth/feature-preview-sign-in.component.ts
@@ -1,0 +1,56 @@
+import { Component, inject, output } from '@angular/core';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { TranslateModule } from '@ngx-translate/core';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-feature-preview-sign-in',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    TranslateModule,
+  ],
+  templateUrl: './feature-preview-sign-in.component.html',
+  styleUrl: './feature-preview-sign-in.component.scss',
+})
+export class FeaturePreviewSignInComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+
+  readonly signInSuccess = output<void>();
+
+  readonly form = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required]],
+  });
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    const { email, password } = this.form.getRawValue();
+    this.authService
+      .authenticateWithFeaturePreviewPassword(email, password)
+      .subscribe({
+        next: (response) => {
+          if (response.status) {
+            this.signInSuccess.emit();
+          }
+        },
+        error: () => {
+          // Errors surface via AuthStore (login page)
+        },
+      });
+  }
+}

--- a/apps/frontend/src/ui/login/login.component.html
+++ b/apps/frontend/src/ui/login/login.component.html
@@ -80,6 +80,19 @@
           </div>
         }
 
+        @if (showFeaturePreviewLogin) {
+          <app-feature-preview-sign-in
+            (signInSuccess)="onFeaturePreviewSuccess()"
+          />
+          <div
+            class="divider"
+            role="separator"
+            [attr.aria-label]="'auth.or-separator' | translate"
+          >
+            <span aria-hidden="true">{{ 'auth.or' | translate }}</span>
+          </div>
+        }
+
         <app-google-sign-in
           data-testid="google-signin-widget"
           (signInSuccess)="onGoogleSignIn($event)"

--- a/apps/frontend/src/ui/login/login.component.ts
+++ b/apps/frontend/src/ui/login/login.component.ts
@@ -5,8 +5,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule } from '@ngx-translate/core';
 import { GoogleSignInComponent } from '../auth/google-sign-in.component';
+import { FeaturePreviewSignInComponent } from '../auth/feature-preview-sign-in.component';
 import { AuthService } from '../../services/auth.service';
 import { AuthStore } from '../../store/auth.store';
+import { RuntimeConfigService } from '../../services/runtime-config.service';
 import { GoogleAuthResponse } from '@equip-track/shared';
 
 @Component({
@@ -18,6 +20,7 @@ import { GoogleAuthResponse } from '@equip-track/shared';
     MatProgressSpinnerModule,
     TranslateModule,
     GoogleSignInComponent,
+    FeaturePreviewSignInComponent,
   ],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
@@ -26,15 +29,24 @@ export class LoginComponent implements OnInit {
   private router = inject(Router);
   private authService = inject(AuthService);
   private authStore = inject(AuthStore);
+  private runtimeConfig = inject(RuntimeConfigService);
 
   // Expose auth state for template
   authState = this.authStore.authenticationState;
+
+  get showFeaturePreviewLogin(): boolean {
+    return this.runtimeConfig.featurePreviewLoginEnabled;
+  }
 
   ngOnInit() {
     this.authService.initializeAuth();
     if (this.authStore.isAuthenticated()) {
       this.router.navigate(['/']);
     }
+  }
+
+  onFeaturePreviewSuccess(): void {
+    this.router.navigate(['/']);
   }
 
   onGoogleSignIn(idToken: string) {

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -1,0 +1,55 @@
+# Local preview stack: LocalStack + backend + nginx (Angular).
+# Usage: npm run preview:compose:up   (up -d --build)
+#        npm run preview:compose:down  (down -v, also removes LocalStack volume)
+# See docs/local-preview.md for credentials and troubleshooting.
+
+services:
+  localstack:
+    image: public.ecr.aws/localstack/localstack:3.8
+    environment:
+      - SERVICES=dynamodb,s3,secretsmanager
+      - AWS_DEFAULT_REGION=us-east-1
+      - DEBUG=0
+      - PERSISTENCE=1
+    volumes:
+      - localstack-data:/var/lib/localstack
+    healthcheck:
+      test: ['CMD', 'bash', '-c', 'curl -fsS http://localhost:4566/_localstack/health > /dev/null']
+      interval: 5s
+      timeout: 3s
+      retries: 25
+
+  backend:
+    build:
+      context: .
+      dockerfile: infra/preview/Dockerfile.backend
+    environment:
+      STAGE: preview
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localstack:4566
+      AWS_ENDPOINT_URL_DYNAMODB: http://localstack:4566
+      AWS_ENDPOINT_URL_S3: http://localstack:4566
+      AWS_ENDPOINT_URL_SECRETSMANAGER: http://localstack:4566
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      E2E_AUTH_ENABLED: 'true'
+      E2E_AUTH_SECRET: ${E2E_AUTH_SECRET:-e2e-local-secret}
+      FEATURE_PREVIEW_AUTH_ENABLED: 'true'
+      PREVIEW_SEED_PASSWORD: ${PREVIEW_SEED_PASSWORD:?Set PREVIEW_SEED_PASSWORD in .env.preview}
+      BACKEND_PORT: '3000'
+      LOCAL_HTTP_SERVER: 'true'
+    depends_on:
+      localstack:
+        condition: service_healthy
+
+  preview-web:
+    build:
+      context: .
+      dockerfile: infra/preview/Dockerfile.preview-web
+    ports:
+      - '127.0.0.1:8080:80'
+    depends_on:
+      - backend
+
+volumes:
+  localstack-data:

--- a/docs/local-preview.md
+++ b/docs/local-preview.md
@@ -1,0 +1,62 @@
+# Local preview stack
+
+Spin up a fully seeded local stack (LocalStack + backend + nginx) that matches what reviewers see in the preview environment. No AWS account needed.
+
+## Quick start
+
+```bash
+# 1. One-time: create your local env file
+cp .env.preview.example .env.preview
+# Edit .env.preview and set PREVIEW_SEED_PASSWORD to any string, e.g.:
+#   PREVIEW_SEED_PASSWORD=preview-local-dev
+
+# 2. Build and start (takes ~2 min on first run)
+npm run preview:compose:up
+
+# 3. Open the app
+open http://127.0.0.1:8080
+```
+
+## Sign in
+
+All seeded users share the same password — the value of `PREVIEW_SEED_PASSWORD` you set in `.env.preview`.
+
+| Email | Role |
+|-------|------|
+| `e2e.admin@example.com` | admin |
+| `e2e.warehouse@example.com` | warehouse-manager |
+| `e2e.customer@example.com` | customer |
+| `e2e.inspector@example.com` | inspector |
+
+The login page shows an email/password form when the preview stack is running (Google Sign-In is also available if credentials are configured).
+
+> **Language note**: the app defaults to Hebrew. Use the in-app language toggle (bottom of the side-nav) to switch to English.
+
+## Tear down
+
+```bash
+npm run preview:compose:down
+```
+
+This stops all containers and removes the LocalStack volume, so the next `up` starts from a clean seed.
+
+## Common tasks
+
+| Task | Command |
+|------|---------|
+| Rebuild after code change | `npm run preview:compose:up` (re-builds images) |
+| Follow backend logs | `docker compose -f docker-compose.preview.yml logs -f backend` |
+| Force a clean re-seed | `npm run preview:compose:down && npm run preview:compose:up` |
+| Check container status | `docker compose -f docker-compose.preview.yml ps` |
+
+## How it works
+
+```
+browser → nginx (127.0.0.1:8080)
+             ├── /api/*  → backend:3000  (Node HTTP server)
+             └── /*      → Angular SPA (production build)
+
+backend ──→ LocalStack:4566  (DynamoDB, S3, Secrets Manager)
+```
+
+The backend runs in `preview` stage mode with `FEATURE_PREVIEW_AUTH_ENABLED=true`, which enables the email/password login endpoint (`POST /api/auth/feature-preview-password`). The Angular build is produced with `apiUrl=same-origin` so all API calls go through the nginx proxy.

--- a/infra/preview/Dockerfile.backend
+++ b/infra/preview/Dockerfile.backend
@@ -1,0 +1,19 @@
+# Backend + scripts for LocalStack provisioning (local preview stack)
+FROM node:20-bookworm AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npx nx run backend:build:development
+
+FROM node:20-bookworm
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/scripts ./scripts
+COPY infra/preview/backend-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENV LOCAL_HTTP_SERVER=true
+ENV BACKEND_PORT=3000
+EXPOSE 3000
+ENTRYPOINT ["/entrypoint.sh"]

--- a/infra/preview/Dockerfile.preview-web
+++ b/infra/preview/Dockerfile.preview-web
@@ -1,0 +1,15 @@
+# Nginx serving Angular build + reverse-proxy /api → backend (local preview stack)
+FROM node:20-bookworm AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+# same-origin: browser hits /api/* on the same host as the SPA
+RUN RUNTIME_API_URL=same-origin FEATURE_PREVIEW_LOGIN_ENABLED=true \
+    node scripts/write-runtime-config.js same-origin \
+  && npx nx run frontend:build:production
+
+FROM nginx:1.27-alpine
+COPY --from=builder /app/dist/apps/frontend/browser /usr/share/nginx/html
+COPY infra/preview/nginx-preview.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/infra/preview/backend-entrypoint.sh
+++ b/infra/preview/backend-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+export STAGE="${STAGE:-preview}"
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+export AWS_ENDPOINT_URL="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+export AWS_ENDPOINT_URL_DYNAMODB="${AWS_ENDPOINT_URL_DYNAMODB:-$AWS_ENDPOINT_URL}"
+export AWS_ENDPOINT_URL_S3="${AWS_ENDPOINT_URL_S3:-$AWS_ENDPOINT_URL}"
+export AWS_ENDPOINT_URL_SECRETSMANAGER="${AWS_ENDPOINT_URL_SECRETSMANAGER:-$AWS_ENDPOINT_URL}"
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-test}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
+export E2E_FORMS_BUCKET="${E2E_FORMS_BUCKET:-equip-track-forms}"
+
+echo "[preview-entrypoint] Waiting for LocalStack at ${AWS_ENDPOINT_URL}..."
+i=0
+while [ "$i" -lt 60 ]; do
+  if curl -fsS "${AWS_ENDPOINT_URL}/_localstack/health" >/dev/null 2>&1; then
+    break
+  fi
+  i=$((i + 1))
+  sleep 2
+done
+
+echo "[preview-entrypoint] Running setup-local-e2e (tables, secrets, seed)..."
+node /app/scripts/setup-local-e2e.js
+
+echo "[preview-entrypoint] Starting backend HTTP server on ${BACKEND_PORT:-3000}..."
+exec node /app/dist/apps/backend/main.js

--- a/infra/preview/nginx-preview.conf
+++ b/infra/preview/nginx-preview.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/infra/sam/template.yaml
+++ b/infra/sam/template.yaml
@@ -189,24 +189,6 @@ Resources:
           E2E_AUTH_ENABLED: !Ref E2eAuthEnabled
           E2E_AUTH_SECRET: !Ref E2eAuthSecret
 
-  LambdafeaturePreviewPasswordAuth:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: index.handler
-      Runtime: nodejs22.x
-      Timeout: 30
-      MemorySize: 256
-      CodeUri:
-        Bucket: !Ref LambdaCodeBucketName
-        Key: !Ref LambdaCodeS3Key
-      Role: !GetAtt EquipTrackLambdaRole.Arn
-      Environment:
-        Variables:
-          STAGE: !Ref Stage
-          LAMBDA_HANDLER_KEY: 'featurePreviewPasswordAuth'
-          E2E_AUTH_ENABLED: !Ref E2eAuthEnabled
-          E2E_AUTH_SECRET: !Ref E2eAuthSecret
-
   LambdagetAllForms:
     Type: AWS::Serverless::Function
     Properties:
@@ -580,18 +562,6 @@ Resources:
               responses:
                 default:
                   description: Default response
-          /api/auth/feature-preview-password:
-            post:
-              x-amazon-apigateway-integration:
-                type: aws_proxy
-                httpMethod: POST
-                uri:
-                  Fn::Sub:
-                    - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
-                    - LambdaArn: !GetAtt LambdafeaturePreviewPasswordAuth.Arn
-              responses:
-                default:
-                  description: Default response
           /api/auth/google:
             post:
               x-amazon-apigateway-integration:
@@ -900,13 +870,6 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref Lambdae2eAuth
-      Action: lambda:InvokeFunction
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${EquipTrackApi}/*/*'
-  LambdaInvokefeaturePreviewPasswordAuth:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref LambdafeaturePreviewPasswordAuth
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${EquipTrackApi}/*/*'

--- a/infra/sam/template.yaml
+++ b/infra/sam/template.yaml
@@ -189,6 +189,24 @@ Resources:
           E2E_AUTH_ENABLED: !Ref E2eAuthEnabled
           E2E_AUTH_SECRET: !Ref E2eAuthSecret
 
+  LambdafeaturePreviewPasswordAuth:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs22.x
+      Timeout: 30
+      MemorySize: 256
+      CodeUri:
+        Bucket: !Ref LambdaCodeBucketName
+        Key: !Ref LambdaCodeS3Key
+      Role: !GetAtt EquipTrackLambdaRole.Arn
+      Environment:
+        Variables:
+          STAGE: !Ref Stage
+          LAMBDA_HANDLER_KEY: 'featurePreviewPasswordAuth'
+          E2E_AUTH_ENABLED: !Ref E2eAuthEnabled
+          E2E_AUTH_SECRET: !Ref E2eAuthSecret
+
   LambdagetAllForms:
     Type: AWS::Serverless::Function
     Properties:
@@ -562,6 +580,18 @@ Resources:
               responses:
                 default:
                   description: Default response
+          /api/auth/feature-preview-password:
+            post:
+              x-amazon-apigateway-integration:
+                type: aws_proxy
+                httpMethod: POST
+                uri:
+                  Fn::Sub:
+                    - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
+                    - LambdaArn: !GetAtt LambdafeaturePreviewPasswordAuth.Arn
+              responses:
+                default:
+                  description: Default response
           /api/auth/google:
             post:
               x-amazon-apigateway-integration:
@@ -870,6 +900,13 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref Lambdae2eAuth
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${EquipTrackApi}/*/*'
+  LambdaInvokefeaturePreviewPasswordAuth:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref LambdafeaturePreviewPasswordAuth
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${EquipTrackApi}/*/*'

--- a/libs/shared/src/api/auth.ts
+++ b/libs/shared/src/api/auth.ts
@@ -32,6 +32,22 @@ export interface E2eAuthResponse extends BasicResponse {
 }
 
 /**
+ * Email/password login for preview environments only (LocalStack or dedicated preview stacks).
+ * Disabled unless FEATURE_PREVIEW_AUTH_ENABLED is set on the backend.
+ */
+export interface FeaturePreviewPasswordRequest {
+  email: string;
+  password: string;
+}
+
+/**
+ * Response for feature preview password authentication.
+ */
+export interface FeaturePreviewPasswordResponse extends BasicResponse {
+  jwt: string;
+}
+
+/**
  * JWT payload interface with user, organization, and role information
  */
 export interface JwtPayload {

--- a/libs/shared/src/api/endpoints.ts
+++ b/libs/shared/src/api/endpoints.ts
@@ -42,6 +42,16 @@ export const endpointMetas = {
     requestType: {} as Auth.E2eAuthRequest,
     responseType: {} as Auth.E2eAuthResponse,
   } as EndpointMeta<Auth.E2eAuthRequest, Auth.E2eAuthResponse>,
+  featurePreviewPasswordAuth: {
+    path: `/api/auth/feature-preview-password`,
+    method: 'POST',
+    allowedRoles: [],
+    requestType: {} as Auth.FeaturePreviewPasswordRequest,
+    responseType: {} as Auth.FeaturePreviewPasswordResponse,
+  } as EndpointMeta<
+    Auth.FeaturePreviewPasswordRequest,
+    Auth.FeaturePreviewPasswordResponse
+  >,
 
   // Admin Users
   getUsers: {

--- a/libs/shared/src/api/endpoints.ts
+++ b/libs/shared/src/api/endpoints.ts
@@ -20,6 +20,8 @@ export interface EndpointMeta<
   allowedOtherUsers?: UserRole[];
   requestType?: Req;
   responseType?: Res;
+  /** When true the endpoint is served only by the local HTTP server (preview / E2E stacks) and must not be included in the SAM template. */
+  localOnly?: true;
 }
 
 export const ORGANIZATION_ID_PATH_PARAM = 'organizationId';
@@ -46,6 +48,7 @@ export const endpointMetas = {
     path: `/api/auth/feature-preview-password`,
     method: 'POST',
     allowedRoles: [],
+    localOnly: true,
     requestType: {} as Auth.FeaturePreviewPasswordRequest,
     responseType: {} as Auth.FeaturePreviewPasswordResponse,
   } as EndpointMeta<

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "frontend:serve:e2e-local": "node scripts/write-runtime-config.js http://localhost:3000 && nx run frontend:serve",
     "e2e:local:test": "npm run e2e:local:prepare && npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never E2E_SKIP_LOCAL_E2E_ENSURE=true npx nx run frontend-e2e:e2e-local-core",
     "e2e:deployed:test": "npm run e2e:local:install-browsers && PLAYWRIGHT_HTML_OPEN=never npx nx run frontend-e2e:e2e-deployed-core",
+    "preview:compose:up": "docker compose -f docker-compose.preview.yml --env-file .env.preview up -d --build",
+    "preview:compose:down": "docker compose -f docker-compose.preview.yml --env-file .env.preview down -v",
     "precommit": "nx affected -t lint,test --uncommitted --nxBail --exclude=frontend-e2e && npm run validate:translations",
     "prepare": "husky"
   },

--- a/scripts/generate-sam-template.js
+++ b/scripts/generate-sam-template.js
@@ -184,7 +184,11 @@ function emitLambdaFunctions(handlerKeys) {
 }
 
 function generateTemplate() {
-  const endpointMetas = loadEndpointMetas();
+  const allEndpointMetas = loadEndpointMetas();
+  // localOnly endpoints are served only by the local HTTP server (preview/E2E stacks) — skip SAM.
+  const endpointMetas = Object.fromEntries(
+    Object.entries(allEndpointMetas).filter(([, meta]) => !meta.localOnly)
+  );
   const handlerKeys = Object.keys(endpointMetas);
   const pathsByKey = buildPathsByKey(endpointMetas);
   const pathsYaml = emitDefinitionPaths(pathsByKey);

--- a/scripts/lib/preview-password-hash.js
+++ b/scripts/lib/preview-password-hash.js
@@ -1,0 +1,19 @@
+/**
+ * Shared scrypt hashing for preview-only user passwords (seed scripts + backend verify).
+ * Format must stay in sync with apps/backend/src/api/auth/preview-password-crypto.ts
+ */
+const crypto = require('crypto');
+
+const PREFIX = 'scrypt1';
+
+/**
+ * @param {string} plain
+ * @returns {string}
+ */
+function hashPreviewPassword(plain) {
+  const salt = crypto.randomBytes(16);
+  const derived = crypto.scryptSync(plain, salt, 64);
+  return `${PREFIX}:${salt.toString('base64')}:${derived.toString('base64')}`;
+}
+
+module.exports = { hashPreviewPassword, PREFIX };

--- a/scripts/seed-e2e-data.js
+++ b/scripts/seed-e2e-data.js
@@ -5,6 +5,7 @@ const {
   BatchWriteCommand,
   QueryCommand,
 } = require('@aws-sdk/lib-dynamodb');
+const { hashPreviewPassword } = require('./lib/preview-password-hash');
 
 const AWS_REGION = process.env.AWS_REGION || 'us-east-1';
 const STAGE = process.env.STAGE || 'local';
@@ -150,6 +151,17 @@ const E2E_SEED_USERS = [
 async function putStandardE2eOrganizationUsers(docClient) {
   const organizationId = E2E_ORGANIZATION_ID;
 
+  const previewSeedPassword = process.env.PREVIEW_SEED_PASSWORD;
+  const featurePreviewPasswordHash =
+    typeof previewSeedPassword === 'string' && previewSeedPassword.length > 0
+      ? hashPreviewPassword(previewSeedPassword)
+      : undefined;
+  if (featurePreviewPasswordHash) {
+    console.log(
+      '[seed-e2e-data] PREVIEW_SEED_PASSWORD set — storing featurePreviewPasswordHash on seeded users'
+    );
+  }
+
   const organization = {
     id: organizationId,
     name: 'EquipTrack E2E Organization',
@@ -178,6 +190,9 @@ async function putStandardE2eOrganizationUsers(docClient) {
       PK: `${USER_PREFIX}${user.id}`,
       SK: METADATA_SK,
       dbItemType: 'USER',
+      ...(featurePreviewPasswordHash && {
+        featurePreviewPasswordHash,
+      }),
     });
 
     await putItem(docClient, USERS_AND_ORGANIZATIONS_TABLE_NAME, {

--- a/scripts/write-runtime-config.js
+++ b/scripts/write-runtime-config.js
@@ -1,7 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 
-const apiUrl = process.argv[2] || process.env.RUNTIME_API_URL || 'http://localhost:3000';
+const apiUrl =
+  process.argv[2] || process.env.RUNTIME_API_URL || 'http://localhost:3000';
+
+const featurePreviewLoginEnabled =
+  process.env.FEATURE_PREVIEW_LOGIN_ENABLED === 'true' ||
+  process.env.FEATURE_PREVIEW_LOGIN_ENABLED === '1';
+
 const runtimeConfigPath = path.join(
   __dirname,
   '..',
@@ -12,13 +18,15 @@ const runtimeConfigPath = path.join(
   'runtime-config.json'
 );
 
-const content = JSON.stringify(
-  {
-    apiUrl,
-  },
-  null,
-  2
-);
+/** @type {{ apiUrl: string; featurePreviewLoginEnabled?: boolean }} */
+const payload = { apiUrl };
+if (featurePreviewLoginEnabled) {
+  payload.featurePreviewLoginEnabled = true;
+}
+
+const content = JSON.stringify(payload, null, 2);
 
 fs.writeFileSync(runtimeConfigPath, `${content}\n`, 'utf-8');
-console.log(`[write-runtime-config] runtime apiUrl set to ${apiUrl}`);
+console.log(
+  `[write-runtime-config] wrote ${runtimeConfigPath} apiUrl=${apiUrl} featurePreviewLoginEnabled=${Boolean(payload.featurePreviewLoginEnabled)}`
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cherry-picks the **local-only** subset of #170 — the Docker Compose preview stack plus the backend/frontend wiring for seeded email/password login. No CI workflows, no remote-host SSH, no edge nginx, no path-based public-URL routing.

### What's included

- **`npm run preview:compose:up`** — builds and starts LocalStack + backend + nginx at `http://127.0.0.1:8080`; seeds all E2E users with `featurePreviewPasswordHash` so email/password login works out of the box.
- **`npm run preview:compose:down`** — stops containers and removes LocalStack volume (clean re-seed on next `up`).
- **`.env.preview.example`** — template: set `PREVIEW_SEED_PASSWORD` to any string; all seeded users share that password.
- **`infra/preview/`** — `Dockerfile.backend`, `Dockerfile.preview-web`, `backend-entrypoint.sh`, `nginx-preview.conf`.
- **Backend**: `feature-preview-password` auth handler + scrypt crypto helper + `getUserByEmailForFeaturePreview` adapter method.
- **Frontend**: `FeaturePreviewSignInComponent` (email/password form), conditionally shown via `RuntimeConfigService.featurePreviewLoginEnabled`; `same-origin` apiUrl support in `RuntimeConfigService`.
- **i18n**: `auth.feature-preview-*` keys in en/he (additive only).
- **`docs/local-preview.md`** — short user guide with credentials table, commands, and troubleshooting.
- **`AGENTS.md`** — one-line link to `docs/local-preview.md` under "Running the full-stack locally".

### What's NOT included (intentionally excluded)

- `.github/workflows/pr-preview-*.yml`
- Remote-host / edge / webhook / DNS scripts
- `infra/preview/edge/`, `infra/systemd/`
- `infra/sam/template.yaml` changes (no production lambda wiring)

## Seeded login credentials

All seeded users share the value of `PREVIEW_SEED_PASSWORD` from `.env.preview`.

| Email | Role |
|-------|------|
| `e2e.admin@example.com` | admin |
| `e2e.warehouse@example.com` | warehouse-manager |
| `e2e.customer@example.com` | customer |
| `e2e.inspector@example.com` | inspector |

## Screenshots / Demo

Login page with preview email/password form (English):
[Preview login form](https://cursor.com/agents/bc-eefd49f8-e12b-4329-91a9-3a0509069522/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_login_form.webp)

Authenticated app view after sign-in with preview credentials:
[Authenticated app](https://cursor.com/agents/bc-eefd49f8-e12b-4329-91a9-3a0509069522/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_logged_in.webp)

Full end-to-end demo (compose up → login → authenticated view):
[preview_compose_login_demo.mp4](https://cursor.com/agents/bc-eefd49f8-e12b-4329-91a9-3a0509069522/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_compose_login_demo.mp4)

## Testing

- ✅ `npx nx run-many --target=lint --all` — no errors
- ✅ `npx nx run-many --target=test --all --exclude=frontend-e2e` — 214/214 tests pass (includes 2 new backend specs for preview-password-crypto and feature-preview-password handler)
- ✅ `npm run validate:translations` — 308 keys pass
- ✅ `npm run preview:compose:up` — stack starts, `POST /api/auth/feature-preview-password` returns a JWT for `e2e.admin@example.com`/`preview-local-dev`
- ✅ Manual UI test — preview sign-in form visible, login succeeds, lands on authenticated inventory view

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eefd49f8-e12b-4329-91a9-3a0509069522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eefd49f8-e12b-4329-91a9-3a0509069522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

