### PR TITLE
feat(trace): link ownership history to forms page in new tab

### DIFF
--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -384,6 +384,7 @@
     "columnOwnershipDate": "Date",
     "columnEventType": "Event type",
     "columnFormId": "Form",
+    "viewFormLink": "View form",
     "checkInEventId": "Return event ID",
     "noOwnershipHistory": "No ownership history",
     "noOwnershipHistoryDescription": "No holder changes have been recorded for this item yet.",

--- a/apps/frontend/src/assets/i18n/he.json
+++ b/apps/frontend/src/assets/i18n/he.json
@@ -383,6 +383,7 @@
     "columnOwnershipDate": "תאריך",
     "columnEventType": "סוג אירוע",
     "columnFormId": "טופס",
+    "viewFormLink": "צפה בטופס",
     "checkInEventId": "מזהה אירוע החזרה",
     "noOwnershipHistory": "אין היסטוריית בעלות",
     "noOwnershipHistoryDescription": "עדיין לא נרשמו שינויי מחזיק עבור פריט זה.",

--- a/apps/frontend/src/ui/trace-item/trace-item.component.html
+++ b/apps/frontend/src/ui/trace-item/trace-item.component.html
@@ -169,7 +169,15 @@
                   {{ 'trace.columnFormId' | translate }}
                 </th>
                 <td mat-cell *matCellDef="let row">
-                  {{ row.formId }}
+                  <a
+                    class="trace-form-link"
+                    [routerLink]="['/forms']"
+                    [queryParams]="ownershipFormListQueryParams(row.formId)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid="trace-ownership-form-link">
+                    {{ 'trace.viewFormLink' | translate }}
+                  </a>
                   @if (row.checkInEventId) {
                     <span class="check-in-event-id" [title]="'trace.checkInEventId' | translate">
                       · {{ row.checkInEventId }}

--- a/apps/frontend/src/ui/trace-item/trace-item.component.scss
+++ b/apps/frontend/src/ui/trace-item/trace-item.component.scss
@@ -124,6 +124,17 @@
     th {
       white-space: nowrap;
     }
+
+    .trace-form-link {
+      color: var(--color-accent);
+      text-decoration: underline;
+    }
+
+    .check-in-event-id {
+      color: var(--color-text-muted);
+      font-size: 0.85em;
+      margin-inline-start: 4px;
+    }
   }
 
   @media (max-width: shared.$mobile-breakpoint) {

--- a/apps/frontend/src/ui/trace-item/trace-item.component.spec.ts
+++ b/apps/frontend/src/ui/trace-item/trace-item.component.spec.ts
@@ -2,10 +2,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
+import { FormStatus, FormType } from '@equip-track/shared';
 import { TraceItemComponent } from './trace-item.component';
 import { ApiService } from '../../services/api.service';
 import { NotificationService } from '../../services/notification.service';
@@ -62,6 +64,7 @@ describe('TraceItemComponent', () => {
         TranslateModule.forRoot(),
       ],
       providers: [
+        provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
         { provide: MatSnackBar, useValue: { open: jest.fn() } },
@@ -136,5 +139,14 @@ describe('TraceItemComponent', () => {
     expect(component.ownershipEventTypeKey('check-in')).toBe(
       'trace.eventType.check-in'
     );
+  });
+
+  it('ownershipFormListQueryParams matches forms deep-link shape for approved check-outs', () => {
+    const formId = 'form-uuid-123';
+    expect(component.ownershipFormListQueryParams(formId)).toEqual({
+      formType: FormType.CheckOut,
+      searchStatus: FormStatus.Approved,
+      searchTerm: formId,
+    });
   });
 });

--- a/apps/frontend/src/ui/trace-item/trace-item.component.ts
+++ b/apps/frontend/src/ui/trace-item/trace-item.component.ts
@@ -20,12 +20,16 @@ import { OrganizationStore, UserStore, InventoryStore } from '../../store';
 import { ApiService } from '../../services/api.service';
 import { NotificationService } from '../../services/notification.service';
 import {
+  FormStatus,
+  FormType,
   ItemReport,
   ORGANIZATION_ID_PATH_PARAM,
   OwnershipEvent,
   Product,
   UI_DATE_TIME_FORMAT,
 } from '@equip-track/shared';
+import { RouterLink } from '@angular/router';
+import { FormQueryParams } from '../../utils/forms.medels';
 
 @Component({
   selector: 'app-trace-item',
@@ -33,6 +37,7 @@ import {
   imports: [
     CommonModule,
     FormsModule,
+    RouterLink,
     MatFormFieldModule,
     MatSelectModule,
     MatButtonModule,
@@ -235,5 +240,14 @@ export class TraceItemComponent {
 
   ownershipEventTypeKey(eventType: OwnershipEvent['eventType']): string {
     return `trace.eventType.${eventType}`;
+  }
+
+  /** Deep link to checkout forms list with filters matching this ownership row's form. */
+  ownershipFormListQueryParams(formId: string): FormQueryParams {
+    return {
+      formType: FormType.CheckOut,
+      searchStatus: FormStatus.Approved,
+      searchTerm: formId,
+    };
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces raw form IDs in the Trace Product ownership history table with a translated **View form** link. The link targets `/forms` in a new tab using the same query parameter contract as other form deep links (`formType=check-out`, `searchStatus=approved`, `searchTerm=<form id>`). Return event ids remain as secondary muted text when present.

## Screenshots

**Before:** the Form column showed long opaque ids (and optional return event suffix).

**After — trace ownership:**

[Ownership history with View form links](https://cursor.com/agents/bc-a46dee10-c3b5-46a4-8438-46131e2d541d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftrace-ownership-form-links.png)

**After — opened forms tab (filtered):**

[Forms page opened from trace link](https://cursor.com/agents/bc-a46dee10-c3b5-46a4-8438-46131e2d541d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftrace-forms-deeplink.png)

## Tests

- `nx run frontend:test` (precommit affected)
- New unit test for `ownershipFormListQueryParams`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a46dee10-c3b5-46a4-8438-46131e2d541d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a46dee10-c3b5-46a4-8438-46131e2d541d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

