### PR TITLE
infra(preview): shrink backend image from ~2.2 GB to ~268 MB

### DIFF
--- a/infra/preview/Dockerfile.backend
+++ b/infra/preview/Dockerfile.backend
@@ -1,4 +1,13 @@
-# Backend + scripts for LocalStack provisioning (local preview stack)
+# Backend + scripts for LocalStack provisioning (local preview stack).
+#
+# Image-size strategy: the @nx/esbuild backend target bundles the app into a
+# single `dist/apps/backend/main.js` and auto-generates a minimal
+# `dist/apps/backend/package.json` listing only the externalized runtime
+# dependencies (AWS SDK clients, google-auth-library, jsonwebtoken, jspdf,
+# uuid, ...). We install ONLY those deps in the runner stage instead of
+# shipping the whole monorepo's `node_modules` (which weighs >1 GB because
+# of Angular / Nx / Playwright dev tooling). The runner also uses
+# `node:20-bookworm-slim` to drop another ~500 MB vs. the full image.
 FROM node:20-bookworm AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -6,13 +15,23 @@ RUN npm ci
 COPY . .
 RUN npx nx run backend:build:development
 
-FROM node:20-bookworm
+FROM node:20-bookworm-slim AS runner
 WORKDIR /app
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/dist ./dist
+
+# Install only the bundled backend's runtime deps using the
+# package.json/package-lock.json that esbuild auto-generated for the bundle.
+# These cover the AWS SDK clients used by the seed scripts as well, so
+# `scripts/setup-local-e2e.js` (run by the entrypoint) resolves them too.
+COPY --from=builder /app/dist/apps/backend/package.json ./package.json
+COPY --from=builder /app/dist/apps/backend/package-lock.json ./package-lock.json
+RUN npm ci --omit=dev --no-audit --no-fund \
+  && npm cache clean --force
+
+COPY --from=builder /app/dist/apps/backend ./dist/apps/backend
 COPY --from=builder /app/scripts ./scripts
 COPY infra/preview/backend-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
 ENV LOCAL_HTTP_SERVER=true
 ENV BACKEND_PORT=3000
 EXPOSE 3000

--- a/infra/preview/backend-entrypoint.sh
+++ b/infra/preview/backend-entrypoint.sh
@@ -14,7 +14,7 @@ export E2E_FORMS_BUCKET="${E2E_FORMS_BUCKET:-equip-track-forms}"
 echo "[preview-entrypoint] Waiting for LocalStack at ${AWS_ENDPOINT_URL}..."
 i=0
 while [ "$i" -lt 60 ]; do
-  if curl -fsS "${AWS_ENDPOINT_URL}/_localstack/health" >/dev/null 2>&1; then
+  if node -e "const u=new URL(process.env.AWS_ENDPOINT_URL+'/_localstack/health');require(u.protocol==='https:'?'https':'http').get(u,r=>process.exit(r.statusCode>=200&&r.statusCode<300?0:1)).on('error',()=>process.exit(1));" >/dev/null 2>&1; then
     break
   fi
   i=$((i + 1))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After running `npm run preview:compose:up`, the `equiptrack-backend` image was **~3.46 GB** on the reporter's machine (~2.2 GB in CI). The bundled backend itself is only ~509 kB of code — the rest was waste.

Root cause, from `docker history`:

| Layer | Size |
|-------|-----:|
| `node:20-bookworm` base | ~1.1 GB |
| `COPY /app/node_modules` (whole monorepo) | **1.11 GB** |
| `COPY /app/dist` (incl. frontend artifacts) | 509 kB |
| `COPY /app/scripts` | 285 kB |

The runner was shipping the whole monorepo's `node_modules` — Angular, Nx, Playwright, `@swc/core`, ESLint, etc. — none of which the bundled, esbuild-produced backend (`dist/apps/backend/main.js`) actually loads at runtime.

## Fix

Nx's `@nx/esbuild` target already writes a minimal `dist/apps/backend/package.json` listing only the externalized runtime deps (10 packages, ~67 MB installed). The new Dockerfile installs **only those** in the runner, on a **slim** base.

- Runner base: `node:20-bookworm` → `node:20-bookworm-slim` (~500 MB saved).
- `COPY node_modules` → `npm ci --omit=dev` against the auto-generated `dist/apps/backend/package.json` (~1.04 GB saved). Those same AWS SDK clients also satisfy `scripts/setup-local-e2e.js` / `seed-e2e-data.js`.
- `COPY /app/dist` → `COPY /app/dist/apps/backend` (no chance of accidentally shipping the frontend bundle).
- Replace `curl`-based LocalStack health probe with a Node one-liner so the slim runner doesn't need to apt-install `curl` + `ca-certificates`.

Builder stage is unchanged (`node:20-bookworm` + full `npm ci`) — that layer is not shipped.

## Result

| | Size |
|-|----:|
| Before | **2.2 GB** (3.46 GB on reporter's Docker storage driver) |
| After  | **268 MB** |
| Reduction | **~88%** |

[Backend image size before/after and layer breakdown](https://cursor.com/agents/bc-4ff67f32-5c4b-4115-bd67-c84876a3a098/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackend_image_size_before_after.log)

## Verification (full preview stack end-to-end)

`npm run preview:compose:up` brings up LocalStack → backend → nginx; backend boots cleanly with the new image:

- LocalStack health probe (Node-based) passes
- `setup-local-e2e.js` creates DynamoDB tables, S3 bucket, JWT keypair in Secrets Manager
- `seed-e2e-data.js` populates seeded users with preview-password hashes
- `POST /api/auth/e2e-login` → 571-char JWT (exercises `@aws-sdk/client-secrets-manager` + `jsonwebtoken`)
- `POST /api/auth/feature-preview-password` → JWT (exercises `@aws-sdk/lib-dynamodb` + `crypto` + `jsonwebtoken`)
- `GET /` (SPA via nginx) → HTTP 200

[preview_stack_smoke_test.log](https://cursor.com/agents/bc-4ff67f32-5c4b-4115-bd67-c84876a3a098/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_stack_smoke_test.log)

## Files changed

- `infra/preview/Dockerfile.backend` — multi-stage redesign described above.
- `infra/preview/backend-entrypoint.sh` — Node-based LocalStack health probe (drop `curl` dependency).

No application or shared library code was modified.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ff67f32-5c4b-4115-bd67-c84876a3a098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ff67f32-5c4b-4115-bd67-c84876a3a098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

