### PR TITLE
feat(frontend): reload inventory data on inventory-by-users

### DIFF
--- a/apps/frontend-e2e/src/screens/inventory-by-users.spec.ts
+++ b/apps/frontend-e2e/src/screens/inventory-by-users.spec.ts
@@ -72,6 +72,55 @@ test.describe('inventory-by-users screen', () => {
     ).toBeVisible({ timeout: 10000 });
   });
 
+  test('reload data keeps selected users and table visible', async ({
+    page,
+    request,
+  }) => {
+    const token = await mintE2eJwt(request, {
+      backendBaseUrl,
+      e2eSecret,
+      userId: 'user-e2e-admin',
+      orgIdToRole: { [E2E_ORG_ID]: UserRole.Admin },
+    });
+
+    await bootstrapAuthenticatedSession(page, token, E2E_ORG_ID);
+    await ensureOrganizationIsSelected(page, E2E_ORG_ID);
+    await clickSideNavRoute(page, 'inventory-by-users');
+    await waitForTestId(page, 'inventory-by-users-page');
+    await expect(
+      page.getByTestId('inventory-by-users-table')
+    ).toBeVisible({ timeout: 20000 });
+
+    const addUserSelect = page.getByTestId(
+      'inventory-by-users-add-user-select'
+    );
+    await addUserSelect.click();
+    const filterInput = addUserSelect.locator('input[type="text"]');
+    await filterInput.fill('customer');
+    await page
+      .getByTestId(
+        `inventory-by-users-add-user-option-${E2E_CUSTOMER_USER_ID}`
+      )
+      .click();
+
+    const chips = page.getByTestId('inventory-by-users-selected-users');
+    await expect(chips.locator('mat-chip-row')).toHaveCount(2, {
+      timeout: 10000,
+    });
+
+    await page.getByTestId('inventory-by-users-reload-data').click();
+
+    await expect.poll(async () => chips.locator('mat-chip-row').count()).toBe(
+      2
+    );
+    await expect(
+      page.getByTestId(`inventory-user-chip-${E2E_CUSTOMER_USER_ID}`)
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('inventory-by-users-table')
+    ).toBeVisible();
+  });
+
   test('show-all adds all users and reset returns to warehouse only', async ({
     page,
     request,

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -224,6 +224,8 @@
       "addUser": "Add User",
       "showAllUsers": "Show All Users",
       "resetToWarehouse": "Reset to Warehouse",
+      "reloadData": "Reload data",
+      "reloadDataTooltip": "Fetch the latest inventory for all selected users and warehouse without changing your selection",
       "clearColumnSort": "Clear Column Sort",
       "sortByProductClick": "Click to sort user columns by this product",
       "product": "Product",

--- a/apps/frontend/src/assets/i18n/he.json
+++ b/apps/frontend/src/assets/i18n/he.json
@@ -223,6 +223,8 @@
       "addUser": "הוסף משתמש",
       "showAllUsers": "הצג את כל המשתמשים",
       "resetToWarehouse": "איפוס למחסן",
+      "reloadData": "טעינת נתונים מחדש",
+      "reloadDataTooltip": "משיכת המלאי העדכני ביותר לכל המשתמשים שנבחרו ולמחסן, בלי לשנות את הבחירה",
       "clearColumnSort": "נקה מיון עמודות",
       "sortByProductClick": "לחץ למיון עמודות המשתמשים לפי מוצר זה",
       "product": "מוצר",

--- a/apps/frontend/src/ui/inventory/by-users/inventory-by-users.component.html
+++ b/apps/frontend/src/ui/inventory/by-users/inventory-by-users.component.html
@@ -82,6 +82,20 @@
 
       <div class="action-buttons">
         <button
+          mat-stroked-button
+          color="primary"
+          type="button"
+          data-testid="inventory-by-users-reload-data"
+          [disabled]="reloadInventoryDisabled()"
+          [matTooltip]="'inventory.table.reloadDataTooltip' | translate"
+          matTooltipPosition="above"
+          (click)="reloadSelectedUsersInventory()"
+        >
+          <mat-icon>refresh</mat-icon>
+          {{ 'inventory.table.reloadData' | translate }}
+        </button>
+
+        <button
           mat-button 
           color="primary"
           data-testid="inventory-by-users-show-all"

--- a/apps/frontend/src/ui/inventory/by-users/inventory-by-users.component.spec.ts
+++ b/apps/frontend/src/ui/inventory/by-users/inventory-by-users.component.spec.ts
@@ -4,6 +4,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { InventoryByUsersComponent } from './inventory-by-users.component';
+import { InventoryStore } from '../../../store/inventory.store';
 import { OrganizationService } from '../../../services/organization.service';
 import {
   UserAndUserInOrganization,
@@ -243,6 +244,51 @@ describe('InventoryByUsersComponent', () => {
       expect(ids).toContain('WAREHOUSE');
       expect(ids).toContain('user-a');
       expect(ids).not.toContain('user-b');
+    });
+  });
+
+  describe('reloadSelectedUsersInventory', () => {
+    it('should call ensureUserInventoryLoaded with forceRefresh for each selected user', async () => {
+      const inventoryStore = TestBed.inject(InventoryStore);
+      const spy = jest
+        .spyOn(inventoryStore, 'ensureUserInventoryLoaded')
+        .mockResolvedValue(undefined);
+
+      component.selectedUserIds.set(['WAREHOUSE', 'user-a', 'user-b']);
+      await component.reloadSelectedUsersInventory();
+
+      expect(spy).toHaveBeenCalledWith('WAREHOUSE', { forceRefresh: true });
+      expect(spy).toHaveBeenCalledWith('user-a', { forceRefresh: true });
+      expect(spy).toHaveBeenCalledWith('user-b', { forceRefresh: true });
+    });
+
+    it('should disable reload while reloadInventoryInProgress is true', async () => {
+      const inventoryStore = TestBed.inject(InventoryStore);
+      let resolveFirst: (() => void) | undefined;
+      const first = new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const spy = jest
+        .spyOn(inventoryStore, 'ensureUserInventoryLoaded')
+        .mockImplementation((_userId, options) => {
+          if (options?.forceRefresh) {
+            return first;
+          }
+          return Promise.resolve();
+        });
+
+      component.selectedUserIds.set(['WAREHOUSE']);
+      const reloadPromise = component.reloadSelectedUsersInventory();
+
+      expect(component.reloadInventoryInProgress()).toBe(true);
+      expect(component.reloadInventoryDisabled()).toBe(true);
+
+      resolveFirst?.();
+      await reloadPromise;
+
+      expect(component.reloadInventoryInProgress()).toBe(false);
+      expect(component.reloadInventoryDisabled()).toBe(false);
+      spy.mockRestore();
     });
   });
 });

--- a/apps/frontend/src/ui/inventory/by-users/inventory-by-users.component.ts
+++ b/apps/frontend/src/ui/inventory/by-users/inventory-by-users.component.ts
@@ -268,6 +268,16 @@ export class InventoryByUsersComponent implements OnInit {
       !this.hasUsers()
   );
 
+  /** True while a manual reload of all selected columns is in flight. */
+  reloadInventoryInProgress = signal(false);
+
+  reloadInventoryDisabled = computed(
+    () =>
+      this.reloadInventoryInProgress() ||
+      this.isLoadingInitialWarehouseInventory() ||
+      this.selectedUserIds().length === 0
+  );
+
   constructor() {
     effect(() => {
       const selectedUsers = this.selectedUserIds();
@@ -347,6 +357,26 @@ export class InventoryByUsersComponent implements OnInit {
   // Reset to warehouse only
   resetToWarehouse() {
     this.selectedUserIds.set(['WAREHOUSE']);
+  }
+
+  /** Refetches inventory for every selected column (warehouse and users) without changing selection. */
+  async reloadSelectedUsersInventory(): Promise<void> {
+    if (this.reloadInventoryInProgress()) {
+      return;
+    }
+    this.reloadInventoryInProgress.set(true);
+    try {
+      const ids = this.selectedUserIds();
+      await Promise.all(
+        ids.map((userId) =>
+          this.inventoryStore.ensureUserInventoryLoaded(userId, {
+            forceRefresh: true,
+          })
+        )
+      );
+    } finally {
+      this.reloadInventoryInProgress.set(false);
+    }
   }
 
   // Get UPI tooltip for a cell


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Reload data** control on the Inventory by Users screen. It calls `InventoryStore.ensureUserInventoryLoaded` with `forceRefresh: true` for the warehouse column and every currently selected user, so people can pull fresh quantities without a full page reload or rebuilding their column selection.

## Implementation notes

- `reloadInventoryInProgress` prevents double-clicks from overlapping refetches.
- The button stays disabled during the initial warehouse load and when there are no selected columns (defensive; the default selection is always warehouse).

## Tests

- Extended `inventory-by-users.component.spec.ts` (store spy + in-progress disabled state).
- New Playwright case `reload data keeps selected users and table visible` in `apps/frontend-e2e/src/screens/inventory-by-users.spec.ts`.

## Screenshot

[Inventory by Users showing Reload data button and multi-column table](https://cursor.com/agents/bc-abbfd4a0-69f0-48e8-a3e3-6b414b1772d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Finventory-by-users-reload-button.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abbfd4a0-69f0-48e8-a3e3-6b414b1772d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abbfd4a0-69f0-48e8-a3e3-6b414b1772d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

