### PR TITLE
feat(frontend): auto-recover from ChunkLoadError after deploy

### DIFF
--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -1,17 +1,19 @@
 import {
+  APP_INITIALIZER,
   ApplicationConfig,
+  ErrorHandler,
+  importProvidersFrom,
   inject,
   provideZoneChangeDetection,
 } from '@angular/core';
-import { provideRouter } from '@angular/router';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideHttpClient,
   HttpClient,
   withInterceptors,
 } from '@angular/common/http';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { MAT_SNACK_BAR_DEFAULT_OPTIONS } from '@angular/material/snack-bar';
-import { APP_INITIALIZER, importProvidersFrom } from '@angular/core';
+import { NavigationError, provideRouter, Router } from '@angular/router';
 
 import { appRoutes } from './app.routes';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
@@ -19,6 +21,8 @@ import { errorInterceptor } from '../services/error-interceptor.service';
 import { RuntimeConfigService } from '../services/runtime-config.service';
 import { VersionedTranslateHttpLoader } from './versioned-translate-http-loader';
 import { AppInitService } from './app.init.service';
+import { ChunkLoadErrorHandler } from './chunk-load-error.handler';
+import { filter } from 'rxjs/operators';
 
 export function translateLoaderFactory(http: HttpClient) {
   return new VersionedTranslateHttpLoader(http);
@@ -31,12 +35,23 @@ export function translateLoaderFactory(http: HttpClient) {
 export function appBootstrapInitializer() {
   const runtimeConfig = inject(RuntimeConfigService);
   const appInitService = inject(AppInitService);
-  return () => runtimeConfig.load().then(() => appInitService.initialize());
+  const router = inject(Router);
+  const errorHandler = inject(ErrorHandler);
+  return () =>
+    runtimeConfig.load().then(async () => {
+      await appInitService.initialize();
+      router.events
+        .pipe(
+          filter((e): e is NavigationError => e instanceof NavigationError)
+        )
+        .subscribe((e) => errorHandler.handleError(e.error));
+    });
 }
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
+    { provide: ErrorHandler, useClass: ChunkLoadErrorHandler },
     provideRouter(appRoutes),
     provideAnimationsAsync(),
     provideHttpClient(withInterceptors([errorInterceptor])),

--- a/apps/frontend/src/app/chunk-load-error.handler.spec.ts
+++ b/apps/frontend/src/app/chunk-load-error.handler.spec.ts
@@ -1,0 +1,90 @@
+import { ErrorHandler } from '@angular/core';
+import { TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
+import { NotificationService } from '../services/notification.service';
+import { ChunkLoadErrorHandler } from './chunk-load-error.handler';
+
+jest.mock('./chunk-load-recovery', () => ({
+  isChunkLoadError: jest.fn(),
+  recoverFromChunkLoadError: jest.fn(),
+}));
+
+import {
+  isChunkLoadError,
+  recoverFromChunkLoadError,
+} from './chunk-load-recovery';
+
+describe('ChunkLoadErrorHandler', () => {
+  let showInfo: jest.Mock;
+  let showError: jest.Mock;
+  let superHandleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    showInfo = jest.fn();
+    showError = jest.fn();
+    superHandleError = jest
+      .spyOn(ErrorHandler.prototype, 'handleError')
+      .mockImplementation(() => undefined);
+
+    (isChunkLoadError as jest.Mock).mockReset();
+    (recoverFromChunkLoadError as jest.Mock).mockReset();
+
+    TestBed.configureTestingModule({
+      providers: [
+        ChunkLoadErrorHandler,
+        {
+          provide: NotificationService,
+          useValue: { showInfo, showError },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    superHandleError.mockRestore();
+  });
+
+  it('calls recoverFromChunkLoadError and shows info snackbar when recovering', fakeAsync(() => {
+    (isChunkLoadError as jest.Mock).mockReturnValue(true);
+    (recoverFromChunkLoadError as jest.Mock).mockResolvedValue('recovering');
+
+    const handler = TestBed.inject(ChunkLoadErrorHandler);
+    handler.handleError(new Error('Loading chunk 1 failed'));
+
+    flushMicrotasks();
+
+    expect(recoverFromChunkLoadError).toHaveBeenCalledTimes(1);
+    expect(showInfo).toHaveBeenCalledWith('common.app-reloading');
+    expect(showError).not.toHaveBeenCalled();
+    expect(superHandleError).not.toHaveBeenCalled();
+  }));
+
+  it('shows error snackbar when recovery gives up', fakeAsync(() => {
+    (isChunkLoadError as jest.Mock).mockReturnValue(true);
+    (recoverFromChunkLoadError as jest.Mock).mockResolvedValue('gave-up');
+
+    const handler = TestBed.inject(ChunkLoadErrorHandler);
+    handler.handleError(new Error('Loading chunk 1 failed'));
+
+    flushMicrotasks();
+
+    expect(showError).toHaveBeenCalledWith(
+      'common.app-reload-failed',
+      undefined,
+      undefined,
+      { duration: 7000 }
+    );
+    expect(showInfo).not.toHaveBeenCalled();
+    expect(superHandleError).not.toHaveBeenCalled();
+  }));
+
+  it('forwards non-chunk errors to super.handleError', () => {
+    (isChunkLoadError as jest.Mock).mockReturnValue(false);
+
+    const handler = TestBed.inject(ChunkLoadErrorHandler);
+    const err = new Error('regular');
+    handler.handleError(err);
+
+    expect(recoverFromChunkLoadError).not.toHaveBeenCalled();
+    expect(superHandleError).toHaveBeenCalledWith(err);
+  });
+});

--- a/apps/frontend/src/app/chunk-load-error.handler.ts
+++ b/apps/frontend/src/app/chunk-load-error.handler.ts
@@ -1,0 +1,30 @@
+import { ErrorHandler, Injectable, inject } from '@angular/core';
+import { NotificationService } from '../services/notification.service';
+import {
+  isChunkLoadError,
+  recoverFromChunkLoadError,
+} from './chunk-load-recovery';
+
+@Injectable()
+export class ChunkLoadErrorHandler extends ErrorHandler {
+  private readonly notificationService = inject(NotificationService);
+
+  override handleError(error: unknown): void {
+    if (isChunkLoadError(error)) {
+      void recoverFromChunkLoadError().then((outcome) => {
+        if (outcome === 'recovering') {
+          this.notificationService.showInfo('common.app-reloading');
+        } else {
+          this.notificationService.showError(
+            'common.app-reload-failed',
+            undefined,
+            undefined,
+            { duration: 7000 }
+          );
+        }
+      });
+      return;
+    }
+    super.handleError(error);
+  }
+}

--- a/apps/frontend/src/app/chunk-load-recovery.spec.ts
+++ b/apps/frontend/src/app/chunk-load-recovery.spec.ts
@@ -1,0 +1,253 @@
+import {
+  CHUNK_RECOVERY_FLAG_KEY,
+  isChunkLoadError,
+  recoverFromChunkLoadError,
+} from './chunk-load-recovery';
+
+describe('isChunkLoadError', () => {
+  const chunkMessages = [
+    'Loading chunk 42 failed',
+    'Failed to fetch dynamically imported module',
+    'error loading dynamically imported module',
+    'Importing a module script failed',
+  ];
+
+  it.each(chunkMessages)('returns true for message: %s', (message) => {
+    expect(isChunkLoadError(new Error(message))).toBe(true);
+    expect(isChunkLoadError(Object.assign(new Error(message), {}))).toBe(true);
+  });
+
+  it('returns true when name is ChunkLoadError', () => {
+    expect(
+      isChunkLoadError(
+        Object.assign(new Error('x'), { name: 'ChunkLoadError' })
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    ['plain Error', new Error('boom')],
+    ['null', null],
+    ['undefined', undefined],
+  ])('returns false for %s', (_label, value) => {
+    expect(isChunkLoadError(value)).toBe(false);
+  });
+
+  it('returns true when the error is a matching string message', () => {
+    expect(isChunkLoadError('Loading chunk 99 failed')).toBe(true);
+  });
+
+  it('returns false for number and empty object', () => {
+    expect(isChunkLoadError(42)).toBe(false);
+    expect(isChunkLoadError({})).toBe(false);
+  });
+
+  it('unwraps { rejection: inner }', () => {
+    const inner = new Error('Loading chunk 7 failed');
+    expect(isChunkLoadError({ rejection: inner })).toBe(true);
+  });
+
+  it('unwraps { reason: inner }', () => {
+    const inner = Object.assign(new Error('x'), {
+      name: 'ChunkLoadError' as const,
+    });
+    expect(isChunkLoadError({ reason: inner })).toBe(true);
+  });
+});
+
+describe('recoverFromChunkLoadError', () => {
+  const reloadGuardWindowMs = 60_000;
+
+  function createStorage(): Storage {
+    const map = new Map<string, string>();
+    return {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        map.set(k, v);
+      },
+      removeItem: (k: string) => {
+        map.delete(k);
+      },
+      clear: () => {
+        map.clear();
+      },
+      key: (index: number) => Array.from(map.keys())[index] ?? null,
+      get length() {
+        return map.size;
+      },
+    } as Storage;
+  }
+
+  it('on first call writes flag, unregisters SWs, clears caches, replaces location, returns recovering', async () => {
+    const storage = createStorage();
+    const replace = jest.fn();
+    const unregisterA = jest.fn().mockResolvedValue(true);
+    const unregisterB = jest.fn().mockResolvedValue(true);
+    const getRegistrations = jest.fn().mockResolvedValue([
+      { unregister: unregisterA },
+      { unregister: unregisterB },
+    ]);
+    const cacheDelete = jest.fn().mockResolvedValue(true);
+    const caches = {
+      keys: jest.fn().mockResolvedValue(['a', 'b']),
+      delete: cacheDelete,
+    } as unknown as CacheStorage;
+
+    const fixedNow = 1_704_000_000_000;
+    const outcome = await recoverFromChunkLoadError({
+      reloadGuardWindowMs,
+      now: () => fixedNow,
+      storage,
+      location: {
+        href: 'https://app.example.org/inventory?foo=1',
+        replace,
+      },
+      navigator: { serviceWorker: { getRegistrations } } as Pick<
+        Navigator,
+        'serviceWorker'
+      >,
+      caches,
+    });
+
+    expect(outcome).toBe('recovering');
+    expect(storage.getItem(CHUNK_RECOVERY_FLAG_KEY)).toBe(String(fixedNow));
+    expect(getRegistrations).toHaveBeenCalledTimes(1);
+    expect(unregisterA).toHaveBeenCalledTimes(1);
+    expect(unregisterB).toHaveBeenCalledTimes(1);
+    expect(caches.keys).toHaveBeenCalledTimes(1);
+    expect(cacheDelete).toHaveBeenCalledWith('a');
+    expect(cacheDelete).toHaveBeenCalledWith('b');
+    expect(replace).toHaveBeenCalledTimes(1);
+    const replaced = replace.mock.calls[0][0] as string;
+    const url = new URL(replaced);
+    expect(url.searchParams.get('_v')).toBe(String(fixedNow));
+    expect(url.pathname).toBe('/inventory');
+    expect(url.searchParams.get('foo')).toBe('1');
+  });
+
+  it('on second call within guard window returns gave-up without side effects', async () => {
+    const storage = createStorage();
+    const replace = jest.fn();
+    const getRegistrations = jest.fn();
+    const caches = {
+      keys: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as CacheStorage;
+
+    const t0 = 5_000;
+    await recoverFromChunkLoadError({
+      reloadGuardWindowMs,
+      now: () => t0,
+      storage,
+      location: { href: 'https://x/', replace },
+      navigator: {
+        serviceWorker: { getRegistrations },
+      } as Pick<Navigator, 'serviceWorker'>,
+      caches,
+    });
+
+    replace.mockClear();
+    getRegistrations.mockClear();
+    (caches.keys as jest.Mock).mockClear();
+    (caches.delete as jest.Mock).mockClear();
+
+    const outcome = await recoverFromChunkLoadError({
+      reloadGuardWindowMs,
+      now: () => t0 + 1000,
+      storage,
+      location: { href: 'https://x/', replace },
+      navigator: {
+        serviceWorker: { getRegistrations },
+      } as Pick<Navigator, 'serviceWorker'>,
+      caches,
+    });
+
+    expect(outcome).toBe('gave-up');
+    expect(replace).toHaveBeenCalledTimes(0);
+    expect(getRegistrations).toHaveBeenCalledTimes(0);
+    expect(caches.keys).toHaveBeenCalledTimes(0);
+  });
+
+  it('on second call after guard window expires recovers again', async () => {
+    const storage = createStorage();
+    const replace = jest.fn();
+    const t0 = 10_000;
+    await recoverFromChunkLoadError({
+      reloadGuardWindowMs,
+      now: () => t0,
+      storage,
+      location: { href: 'https://x/y', replace },
+      navigator: undefined,
+      caches: undefined,
+    });
+    replace.mockClear();
+
+    const t1 = t0 + reloadGuardWindowMs + 1;
+    const outcome = await recoverFromChunkLoadError({
+      reloadGuardWindowMs,
+      now: () => t1,
+      storage,
+      location: { href: 'https://x/y', replace },
+      navigator: undefined,
+      caches: undefined,
+    });
+
+    expect(outcome).toBe('recovering');
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(new URL(replace.mock.calls[0][0] as string).searchParams.get('_v')).toBe(
+      String(t1)
+    );
+  });
+
+  it('when navigator.serviceWorker is undefined still replaces', async () => {
+    const replace = jest.fn();
+    await recoverFromChunkLoadError({
+      reloadGuardWindowMs,
+      now: () => 123,
+      storage: createStorage(),
+      location: { href: 'https://z/', replace },
+      navigator: undefined,
+      caches: undefined,
+    });
+    expect(replace).toHaveBeenCalledTimes(1);
+  });
+
+  it('when caches is undefined still replaces', async () => {
+    const replace = jest.fn();
+    await recoverFromChunkLoadError({
+      reloadGuardWindowMs,
+      now: () => 456,
+      storage: createStorage(),
+      location: { href: 'https://z/', replace },
+      navigator: { serviceWorker: undefined } as Pick<
+        Navigator,
+        'serviceWorker'
+      >,
+      caches: undefined,
+    });
+    expect(replace).toHaveBeenCalledTimes(1);
+  });
+
+  it('when caches.delete rejects for one key recovery still proceeds', async () => {
+    const replace = jest.fn();
+    const cacheDelete = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('delete failed'))
+      .mockResolvedValueOnce(true);
+    const caches = {
+      keys: jest.fn().mockResolvedValue(['bad', 'good']),
+      delete: cacheDelete,
+    } as unknown as CacheStorage;
+
+    await recoverFromChunkLoadError({
+      reloadGuardWindowMs,
+      now: () => 999,
+      storage: createStorage(),
+      location: { href: 'https://z/', replace },
+      navigator: undefined,
+      caches,
+    });
+
+    expect(replace).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/app/chunk-load-recovery.ts
+++ b/apps/frontend/src/app/chunk-load-recovery.ts
@@ -1,0 +1,177 @@
+export const CHUNK_RECOVERY_FLAG_KEY = 'equip-track-chunk-recovered-at';
+
+const CHUNK_MESSAGE_PATTERNS: readonly RegExp[] = [
+  /Loading chunk [^ ]+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+];
+
+function getErrorName(error: unknown): string | undefined {
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'name' in error &&
+    typeof (error as { name: unknown }).name === 'string'
+  ) {
+    return (error as { name: string }).name;
+  }
+  return undefined;
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  ) {
+    return (error as { message: string }).message;
+  }
+  return undefined;
+}
+
+function messageMatchesChunkFailure(message: string): boolean {
+  return CHUNK_MESSAGE_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+function matchesChunkLoadSignature(error: unknown): boolean {
+  if (getErrorName(error) === 'ChunkLoadError') {
+    return true;
+  }
+  const message = getErrorMessage(error);
+  return message !== undefined && messageMatchesChunkFailure(message);
+}
+
+function unwrapRejectionOrReason(error: unknown): unknown {
+  if (error === null || typeof error !== 'object') {
+    return error;
+  }
+  const record = error as Record<string, unknown>;
+  if ('rejection' in record && record['rejection'] !== undefined) {
+    return record['rejection'];
+  }
+  if ('reason' in record && record['reason'] !== undefined) {
+    return record['reason'];
+  }
+  return error;
+}
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (matchesChunkLoadSignature(error)) {
+    return true;
+  }
+  const inner = unwrapRejectionOrReason(error);
+  if (inner !== error) {
+    return matchesChunkLoadSignature(inner);
+  }
+  return false;
+}
+
+export interface ChunkLoadRecoveryDeps {
+  reloadGuardWindowMs?: number;
+  now?: () => number;
+  storage?: Storage;
+  location?: Pick<Location, 'href' | 'replace'>;
+  navigator?: Pick<Navigator, 'serviceWorker'>;
+  caches?: CacheStorage;
+}
+
+const DEFAULT_RELOAD_GUARD_MS = 60_000;
+
+function readSessionStorage(): Storage | undefined {
+  if (typeof globalThis === 'undefined') {
+    return undefined;
+  }
+  try {
+    return globalThis.sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function readLocation(): Pick<Location, 'href' | 'replace'> | undefined {
+  if (typeof globalThis === 'undefined' || !('location' in globalThis)) {
+    return undefined;
+  }
+  return globalThis.location as Pick<Location, 'href' | 'replace'>;
+}
+
+function readNavigator(): Pick<Navigator, 'serviceWorker'> | undefined {
+  if (typeof globalThis === 'undefined' || !('navigator' in globalThis)) {
+    return undefined;
+  }
+  return globalThis.navigator as Pick<Navigator, 'serviceWorker'>;
+}
+
+function readCaches(): CacheStorage | undefined {
+  if (typeof globalThis === 'undefined' || !('caches' in globalThis)) {
+    return undefined;
+  }
+  const c = (globalThis as { caches?: CacheStorage }).caches;
+  return c;
+}
+
+export async function recoverFromChunkLoadError(
+  deps?: ChunkLoadRecoveryDeps
+): Promise<'recovering' | 'gave-up'> {
+  const reloadGuardWindowMs =
+    deps?.reloadGuardWindowMs ?? DEFAULT_RELOAD_GUARD_MS;
+  const now = deps?.now ?? Date.now;
+  const storage = deps?.storage ?? readSessionStorage();
+  const locationRef = deps?.location ?? readLocation();
+  const navigatorRef = deps?.navigator ?? readNavigator();
+  const cachesRef = deps?.caches ?? readCaches();
+
+  const t = now();
+
+  if (storage) {
+    const raw = storage.getItem(CHUNK_RECOVERY_FLAG_KEY);
+    if (raw !== null && raw !== '') {
+      const parsed = Number.parseInt(raw, 10);
+      if (!Number.isNaN(parsed) && t - parsed < reloadGuardWindowMs) {
+        return 'gave-up';
+      }
+    }
+    storage.setItem(CHUNK_RECOVERY_FLAG_KEY, String(t));
+  }
+
+  if (
+    navigatorRef &&
+    'serviceWorker' in navigatorRef &&
+    navigatorRef.serviceWorker
+  ) {
+    try {
+      const registrations =
+        await navigatorRef.serviceWorker.getRegistrations();
+      await Promise.allSettled(
+        registrations.map((registration) => registration.unregister())
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (cachesRef) {
+    try {
+      const keys = await cachesRef.keys();
+      await Promise.allSettled(keys.map((key) => cachesRef.delete(key)));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (locationRef) {
+    const url = new URL(locationRef.href);
+    url.searchParams.set('_v', String(t));
+    locationRef.replace(url.toString());
+  }
+
+  return 'recovering';
+}

--- a/apps/frontend/src/assets/i18n/en.json
+++ b/apps/frontend/src/assets/i18n/en.json
@@ -61,6 +61,8 @@
     "email-request-generated": "Email client opened with access request",
     "email-request-failed": "Failed to generate access request",
     "navigation-failed": "Navigation failed. Please try again.",
+    "app-reloading": "Updating the app…",
+    "app-reload-failed": "We couldn't refresh the app automatically. Please reload the page (Ctrl+Shift+R).",
     "confirm": "Confirm",
     "unsaved-changes-warning": "You have unsaved changes. Are you sure you want to leave this page?",
     "leave": "Leave",

--- a/apps/frontend/src/assets/i18n/he.json
+++ b/apps/frontend/src/assets/i18n/he.json
@@ -61,6 +61,8 @@
     "email-request-generated": "לקוח הדוא\"ל נפתח עם בקשת גישה",
     "email-request-failed": "יצירת בקשת גישה נכשלה",
     "navigation-failed": "הניווט נכשל. נסה שוב.",
+    "app-reloading": "מעדכן את האפליקציה…",
+    "app-reload-failed": "לא הצלחנו לרענן את האפליקציה אוטומטית. נא לרענן את הדף (Ctrl+Shift+R).",
     "confirm": "אישור",
     "unsaved-changes-warning": "יש לך שינויים שלא נשמרו. האם אתה בטוח שברצונך לעזוב את הדף?",
     "leave": "עזוב",

--- a/apps/frontend/src/index.html
+++ b/apps/frontend/src/index.html
@@ -5,6 +5,9 @@
     <title>frontend</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <!-- Allow Google Sign-In to work with COOP -->
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After each frontend deploy, some users see screens that silently fail to load. Every route in `app.routes.ts` is lazy-loaded (`loadComponent: () => import(...)`). The production build uses content-hashed chunks (`outputHashing: "all"`), and `aws s3 sync … --delete` removes old chunk files as soon as a new version is published.

If a user still has an old `index.html` or main bundle (memory or HTTP disk cache) and opens a route they have not visited yet, the browser requests `import("chunk-OLDHASH.js")`. S3 may return the SPA fallback (`index.html` as HTML instead of JavaScript), which surfaces as `ChunkLoadError`, `Failed to fetch dynamically imported module`, or similar. Nothing in the app handled that before, so the route never rendered. A normal reload is not always enough when a stale `index.html` remains cached.

## What we changed

- Added a pure helper `chunk-load-recovery.ts` with `isChunkLoadError()`, `recoverFromChunkLoadError()`, and a session-scoped reload guard (`CHUNK_RECOVERY_FLAG_KEY` / `equip-track-chunk-recovered-at`).
- Recovery flow (when a chunk-load failure is detected): optionally unregister any service workers (none are shipped today, but this is defensive), clear `CacheStorage` keys, then `location.replace` the current URL with a new `_v=<timestamp>` query parameter so the browser cannot reuse a bad cached document. **`localStorage` is never cleared** — JWT, language, and selected org stay intact.
- `ChunkLoadErrorHandler` extends Angular `ErrorHandler`, delegates non-chunk errors to the default handler, and uses `NotificationService` for user feedback (`common.app-reloading` vs `common.app-reload-failed` with a longer error duration when recovery is skipped inside the 60s guard window).
- `app.config.ts` registers the custom `ErrorHandler` and, after bootstrap, subscribes to `Router` `NavigationError` events so lazy-route failures that surface as navigation errors are forwarded to the same handler.
- Added cache-related `<meta http-equiv="…">` tags in `index.html` as an extra hint for proxies or tools that honor meta cache directives.

**No service worker** is introduced (`provideServiceWorker`, `ngsw-config.json`, etc. remain unused).

## Reload-loop guard

`recoverFromChunkLoadError` writes `sessionStorage['equip-track-chunk-recovered-at']` before attempting recovery. If that timestamp is present and less than 60 seconds old, the function returns `'gave-up'` without calling `location.replace` again, so a persistent failure cannot spin forever. The handler then shows `common.app-reload-failed` asking the user for a hard reload.

## Verification

- `npx nx run frontend:lint`
- `npx nx run frontend:test` (includes new `chunk-load-recovery.spec.ts` and `chunk-load-error.handler.spec.ts`)
- `npm run validate:translations`

Manual browser automation in this environment could not drive Angular’s `ErrorHandler` from ad-hoc console events; behavior is covered by the new unit tests. Headless screenshots below illustrate (1) a cache-busted URL with `_v=` after the same style of navigation recovery uses, and (2) the English copy used for the “reload failed” path (styled similarly to a snackbar for visibility; the real control remains `MatSnackBar` via `NotificationService`).

[Cache-busted URL after soft reload](https://cursor.com/agents/bc-aa1f16bd-7f4e-42d7-a7ca-4b73c6419f20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchunk-recovery-after-replace.png)

[Reload failed copy (simulated snackbar styling)](https://cursor.com/agents/bc-aa1f16bd-7f4e-42d7-a7ca-4b73c6419f20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchunk-recovery-gave-up-snackbar-simulated.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa1f16bd-7f4e-42d7-a7ca-4b73c6419f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa1f16bd-7f4e-42d7-a7ca-4b73c6419f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

