### PR TITLE
ci: run LocalStack full regression earlier (00:15 UTC)

### DIFF
--- a/.github/workflows/e2e-localstack-full-regression.yml
+++ b/.github/workflows/e2e-localstack-full-regression.yml
@@ -3,7 +3,8 @@ name: E2E LocalStack Full Regression
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * *' # Nightly at 03:00 UTC
+    # Earlier than 03:00 UTC; minute 15 avoids the busiest :00 cron boundary (Actions may still delay runs).
+    - cron: '15 0 * * *' # Nightly ~00:15 UTC
 
 concurrency:
   group: e2e-localstack-full-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The **E2E Deployed Core Regression** workflow can also be triggered manually (`w
 
 ### Nightly full regression
 
-The **E2E LocalStack Full Regression** workflow is scheduled every night at **03:00 UTC**. It runs the complete Playwright suite against LocalStack only when `develop` has new commits or the package version changed since the last **successful** run; otherwise the workflow exits after a quick check. Manual runs (`workflow_dispatch`) always execute the full suite.
+The **E2E LocalStack Full Regression** workflow is scheduled every night at **00:15 UTC**. It runs the complete Playwright suite against LocalStack only when `develop` has new commits or the package version changed since the last **successful** run; otherwise the workflow exits after a quick check. Manual runs (`workflow_dispatch`) always execute the full suite. GitHub may start scheduled runs later than the cron time when Actions load is high.
 
 ### Workflow summary
 
@@ -254,4 +254,4 @@ The **E2E LocalStack Full Regression** workflow is scheduled every night at **03
 | Deploy Full Stack to AWS | Version tag `v*` |
 | E2E Deployed Core After Develop Deploy | After successful dev deploy |
 | E2E Deployed Core Regression | Manual (`workflow_dispatch`) |
-| E2E LocalStack Full Regression | Nightly 03:00 UTC |
+| E2E LocalStack Full Regression | Nightly 00:15 UTC |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The nightly **E2E LocalStack Full Regression** workflow was scheduled at `0 3 * * *` (03:00 UTC). In practice, GitHub Actions often started runs hours later, which landed around morning in Israel.

This change moves the cron to **`15 0 * * *` (00:15 UTC)** so the intended window is earlier. The **minute offset** avoids the busiest `:00` boundary where many repositories schedule jobs, which can reduce queue delay (GitHub still does not guarantee exact start times).

## Docs

- `README.md`: updated the nightly time and noted that GitHub may delay scheduled runs under load.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f85469f-7934-4032-b433-aefeff50f9d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f85469f-7934-4032-b433-aefeff50f9d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

