### PR TITLE
fix(e2e): align my-forms spec with single check-out tab

### DIFF
--- a/apps/frontend-e2e/src/screens/my-forms.spec.ts
+++ b/apps/frontend-e2e/src/screens/my-forms.spec.ts
@@ -14,7 +14,7 @@ const backendBaseUrl =
 const e2eSecret = process.env['E2E_AUTH_SECRET'] || 'e2e-local-secret';
 
 test.describe('my-forms screen (customer)', () => {
-  test('customer sees their forms with tabs', async ({ page, request }) => {
+  test('customer sees their check-out forms tab', async ({ page, request }) => {
     const token = await mintE2eJwt(request, {
       backendBaseUrl,
       e2eSecret,
@@ -27,8 +27,9 @@ test.describe('my-forms screen (customer)', () => {
     await clickSideNavRoute(page, 'my-forms');
 
     await waitForTestId(page, 'forms-tab-group');
+    // Single tab (check-out only); check-in lives on approved form cards / dialogs.
     await expect(page.getByRole('tab', { name: /Check Out/i })).toBeVisible();
-    await expect(page.getByRole('tab', { name: /Check In/i })).toBeVisible();
+    await expect(page.getByTestId('forms-checkout-content')).toBeVisible();
   });
 
   test('status filter works for customer forms', async ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The scheduled **E2E LocalStack Full Regression** on `develop` failed (run [25983176120](https://github.com/NetanelAlbert/EquipTrack/actions/runs/25983176120)): `my-forms.spec.ts` expected a **Check In** tab that no longer exists on the forms UI.

`app-forms` now only renders the check-out tab (`forms.component.html`); `forms.spec.ts` already documents this. The customer **my-forms** screen uses the same component, so the test was updated accordingly.

## Changes

- Drop the obsolete **Check In** tab assertion.
- Assert the check-out tab and `forms-checkout-content` are visible.
- Rename the test to describe the current behavior.

## Verification

- `npx nx run frontend-e2e:e2e-local-full` — **60 passed** (LocalStack + Playwright).

No open PR was addressing this failure at the time of the fix (only unrelated draft PRs).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c71df6b-4471-41bb-bb5c-a490c396caf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c71df6b-4471-41bb-bb5c-a490c396caf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

